### PR TITLE
Update to moonc v0.1.20241231+ba15a9a4e

### DIFF
--- a/ast.mbt
+++ b/ast.mbt
@@ -1,3 +1,4 @@
+///|
 priv enum AstNodeInternal {
   // Leave nodes of the AST.
   Empty
@@ -19,6 +20,7 @@ priv enum AstNodeInternal {
   Group
 } derive(Eq)
 
+///|
 fn to_string(self : AstNodeInternal) -> String {
   fn range_str(min : Int, max : Int?) {
     match max {
@@ -66,12 +68,14 @@ fn to_string(self : AstNodeInternal) -> String {
   }
 }
 
+///|
 priv struct AstNode {
   internal : AstNodeInternal
   mut parent : AstNode?
   children : Array[AstNode]
 }
 
+///|
 fn AstNode::new(
   internal : AstNodeInternal,
   parent~ : AstNode? = None,
@@ -80,19 +84,23 @@ fn AstNode::new(
   { internal, parent, children }
 }
 
+///|
 fn add_child(self : AstNode, child : AstNode) -> Unit {
   child.parent = Some(self)
   self.children.push(child)
 }
 
+///|
 fn get_child(self : AstNode, idx : Int) -> AstNode {
   self.children[idx]
 }
 
+///|
 fn child_num(self : AstNode) -> Int {
   self.children.length()
 }
 
+///|
 fn to_string(self : AstNode) -> String {
   let buf = @buffer.new()
   let mut cur_node = self
@@ -121,15 +129,17 @@ fn to_string(self : AstNode) -> String {
       }
     }
   }
-  buf.to_unchecked_string()
+  buf.contents().to_unchecked_string()
 }
 
+///|
 priv struct Ast {
   root : AstNode
   capture_num : Int
   capture_name_mapping : Map[String, Int]
 }
 
+///|
 impl Show for Ast with output(self, logger) {
   logger.write_char('\n')
   logger.write_string("Number of captures: " + self.capture_num.to_string())
@@ -141,6 +151,7 @@ impl Show for Ast with output(self, logger) {
   logger.write_string(self.root.to_string())
 }
 
+///|
 fn to_string(self : Ast) -> String {
   Show::to_string(self)
 }

--- a/char_class.mbt
+++ b/char_class.mbt
@@ -1,9 +1,11 @@
+///|
 priv struct CharClass {
   neg : Bool
   ranges : Array[Int]
   categories : Array[CharClassCategory]
 } derive(Eq)
 
+///|
 priv enum CharClassCategory {
   Digit
   NotDigit
@@ -13,6 +15,7 @@ priv enum CharClassCategory {
   NotWord
 } derive(Eq)
 
+///|
 fn CharClass::new(
   neg~ : Bool = false,
   ranges~ : Array[Int] = [],
@@ -21,29 +24,34 @@ fn CharClass::new(
   { neg, ranges, categories }
 }
 
+///|
 fn add_single(self : CharClass, char : Char) -> Unit {
   self.ranges.push(char.to_int())
   self.ranges.push(char.to_int())
 }
 
+///|
 fn add_range(self : CharClass, low : Char, high : Char) -> Unit {
   self.ranges.push(low.to_int())
   self.ranges.push(high.to_int())
 }
 
+///|
 fn add_category(self : CharClass, category : CharClassCategory) -> Unit {
   self.categories.push(category)
 }
 
+///|
 fn contains(self : CharClass, char : Int) -> Bool {
   let result = self.ranges_contains(char) || self.categories_contains(char)
   if self.neg {
-    result.not()
+    not(result)
   } else {
     result
   }
 }
 
+///|
 fn ranges_contains(self : CharClass, char : Int) -> Bool {
   for i = 0; i < self.ranges.length(); i = i + 2 {
     let low = self.ranges[i]
@@ -56,15 +64,16 @@ fn ranges_contains(self : CharClass, char : Int) -> Bool {
   }
 }
 
+///|
 fn categories_contains(self : CharClass, char : Int) -> Bool {
   for category in self.categories {
     let res = match category {
       Digit => is_digit(char)
-      NotDigit => is_digit(char).not()
+      NotDigit => not(is_digit(char))
       Space => is_whitespace(char)
-      NotSpace => is_whitespace(char).not()
+      NotSpace => not(is_whitespace(char))
       Word => is_word_char(char)
-      NotWord => is_word_char(char).not()
+      NotWord => not(is_word_char(char))
     }
     if res {
       break true
@@ -74,6 +83,7 @@ fn categories_contains(self : CharClass, char : Int) -> Bool {
   }
 }
 
+///|
 impl Show for CharClass with output(self, logger) -> Unit {
   logger.write_char('[')
   if self.neg {
@@ -106,10 +116,12 @@ impl Show for CharClass with output(self, logger) -> Unit {
   logger.write_char(']')
 }
 
+///|
 fn to_string(self : CharClass) -> String {
   Show::to_string(self)
 }
 
+///|
 fn is_whitespace(char : Int) -> Bool {
   return char == ' '.to_int() ||
     char == '\t'.to_int() ||
@@ -134,6 +146,7 @@ fn is_whitespace(char : Int) -> Bool {
     char == '\u2029'.to_int()
 }
 
+///|
 fn is_word_char(char : Int) -> Bool {
   return (char >= 'a'.to_int() && char <= 'z'.to_int()) ||
     (char >= 'A'.to_int() && char <= 'Z'.to_int()) ||
@@ -141,6 +154,7 @@ fn is_word_char(char : Int) -> Bool {
     char == '_'.to_int()
 }
 
+///|
 fn is_digit(char : Int) -> Bool {
   return char >= '0'.to_int() && char <= '9'.to_int()
 }

--- a/emitter.mbt
+++ b/emitter.mbt
@@ -1,8 +1,10 @@
+///|
 priv enum TraverseStatus {
   BeforeChild
   AfterChild
 }
 
+///|
 priv struct Emitter {
   ast : Ast
   bytecodes : Array[Int]
@@ -10,41 +12,50 @@ priv struct Emitter {
   stack : Array[Int]
 }
 
+///|
 fn Emitter::new(ast : Ast) -> Emitter {
   { ast, bytecodes: [], classes: [], stack: [] }
 }
 
+///|
 fn push_stack(self : Emitter, val : Int) -> Unit {
   self.stack.push(val)
 }
 
+///|
 fn pop_stack(self : Emitter) -> Int {
   self.stack.unsafe_pop()
 }
 
+///|
 fn cur_pos(self : Emitter) -> Int {
   self.bytecodes.length()
 }
 
+///|
 fn patch_jump(self : Emitter, offset : Int, dest : Int) -> Unit {
   self.bytecodes[offset + 1] = dest
 }
 
+///|
 fn emit_0(self : Emitter, op : OpCode) -> Unit {
   self.bytecodes.push(op.to_bytecode())
 }
 
+///|
 fn emit_1(self : Emitter, op : OpCode, operand : Int) -> Unit {
   self.bytecodes.push(op.to_bytecode())
   self.bytecodes.push(operand)
 }
 
+///|
 fn emit_2(self : Emitter, op : OpCode, operand1 : Int, operand2 : Int) -> Unit {
   self.bytecodes.push(op.to_bytecode())
   self.bytecodes.push(operand1)
   self.bytecodes.push(operand2)
 }
 
+///|
 fn emit(self : Emitter) -> Program {
   self.emit_1(BranchLazy, 0)
   let mut cur_node = self.ast.root
@@ -78,6 +89,7 @@ fn emit(self : Emitter) -> Program {
   }
 }
 
+///|
 fn emit_fragment(
   self : Emitter,
   node : AstNode,
@@ -103,7 +115,7 @@ fn emit_fragment(
         }
       }
     (Loop(min~, max~, ..), BeforeChild) => {
-      if min > 1 || max.is_empty().not() {
+      if min > 1 || not(max.is_empty()) {
         if min == 0 {
           self.emit_1(NullCount, 0)
         } else {
@@ -121,7 +133,7 @@ fn emit_fragment(
     }
     (Loop(min~, max~, greedy~), AfterChild) => {
       let jump_dest = self.cur_pos()
-      if min > 1 || max.is_empty().not() {
+      if min > 1 || not(max.is_empty()) {
         let opcode : OpCode = if greedy { BranchCount } else { BranchCountLazy }
         let count = if max.is_empty() {
           @int.max_value

--- a/emitter_wbtest.mbt
+++ b/emitter_wbtest.mbt
@@ -1,3 +1,4 @@
+///|
 fn test_emit(ast : Ast) -> Program {
   Emitter::new(ast).emit()
 }

--- a/interpreter.mbt
+++ b/interpreter.mbt
@@ -1,9 +1,11 @@
+///|
 priv enum RunningStatus {
   Normal
   Backtracking
   BacktrackingBranch
 } derive(Show, Eq)
 
+///|
 priv struct Interpreter {
   prog : Program
   mut status : RunningStatus
@@ -19,6 +21,7 @@ priv struct Interpreter {
   captures : Array[(Int, Int)?]
 }
 
+///|
 fn Interpreter::new(prog : Program) -> Interpreter {
   {
     prog,
@@ -36,20 +39,24 @@ fn Interpreter::new(prog : Program) -> Interpreter {
   }
 }
 
+///|
 fn advance(self : Interpreter, num : Int) -> Unit {
   self.op_pos += num
   self.op_code = self.prog.op_code(self.op_pos)
 }
 
+///|
 fn goto(self : Interpreter, pos : Int) -> Unit {
   self.op_pos = pos
   self.op_code = self.prog.op_code(self.op_pos)
 }
 
+///|
 fn operand(self : Interpreter, n : Int) -> Int {
   self.prog.operand(self.op_pos + n + 1)
 }
 
+///|
 fn backtrack(self : Interpreter) -> Unit {
   let op_pos = self.op_pop()
   if op_pos < 0 {
@@ -62,59 +69,72 @@ fn backtrack(self : Interpreter) -> Unit {
   self.op_code = self.prog.op_code(self.op_pos)
 }
 
+///|
 fn capture(self : Interpreter, idx : Int, start : Int, end : Int) -> Unit {
   let (start, end) = if end < start { (end, start) } else { (start, end) }
   self.capture_stack.push(idx)
   self.captures[idx] = Some((start, end))
 }
 
+///|
 fn uncapture(self : Interpreter) -> Unit {
   let idx = self.capture_stack.unsafe_pop()
   self.captures[idx] = None
 }
 
+///|
 fn op_push(self : Interpreter, branch~ : Bool = false) -> Unit {
   self.op_stack.push(if branch { -self.op_pos } else { self.op_pos })
 }
 
+///|
 fn op_pop(self : Interpreter) -> Int {
   self.op_stack.unsafe_pop()
 }
 
+///|
 fn track_push(self : Interpreter, arg : Int) -> Unit {
   self.track_stack.push(arg)
 }
 
+///|
 fn track_pop(self : Interpreter) -> Int {
   self.track_stack.unsafe_pop()
 }
 
+///|
 fn run_push(self : Interpreter, arg : Int) -> Unit {
   self.run_stack.push(arg)
 }
 
+///|
 fn run_pop(self : Interpreter) -> Int {
   self.run_stack.unsafe_pop()
 }
 
+///|
 fn chars_remain(self : Interpreter) -> Int {
   self.text_end - self.text_pos
 }
 
+///|
 fn next_char(self : Interpreter, text : String) -> Int {
   self.text_pos += 1
   text[self.text_pos - 1].to_int()
 }
 
+///|
 fn rewind(self : Interpreter) -> Unit {
   self.text_pos -= 1
 }
 
+///|
 fn char_in_class(self : Interpreter, class_idx : Int, char : Int) -> Bool {
   let class = self.prog.classes[class_idx]
   class.contains(char)
 }
 
+///|
 fn scan(
   self : Interpreter,
   text : String,
@@ -130,16 +150,14 @@ fn scan(
     }
     self.text_pos += 1
   }
-  let captures = self.captures.map(
-    fn(r) {
-      if r == None {
-        ""
-      } else {
-        let (start, end) = r.unwrap()
-        text.substring(start~, end~)
-      }
-    },
-  )
+  let captures = self.captures.map(fn(r) {
+    if r == None {
+      ""
+    } else {
+      let (start, end) = r.unwrap()
+      text.substring(start~, end~)
+    }
+  })
   let named_captures = {}
   for k, v in self.prog.capture_name_mapping {
     named_captures[k] = captures[v]
@@ -147,6 +165,7 @@ fn scan(
   { success: self.captures[0] != None, captures, named_captures }
 }
 
+///|
 fn try_match(self : Interpreter, text : String) -> Bool {
   self.op_pos = 0
   self.op_code = self.prog.op_code(self.op_pos)
@@ -447,7 +466,7 @@ fn try_match(self : Interpreter, text : String) -> Bool {
           matched = false
         } else {
           for i = 0; i < count; i = i + 1 {
-            if self.char_in_class(class_idx, self.next_char(text)).not() {
+            if not(self.char_in_class(class_idx, self.next_char(text))) {
               matched = false
               self.rewind()
               break
@@ -504,7 +523,7 @@ fn try_match(self : Interpreter, text : String) -> Bool {
         let count = @math.minimum(max_count, self.chars_remain())
         let mut i = count
         while i > 0 {
-          if self.char_in_class(self.operand(0), self.next_char(text)).not() {
+          if not(self.char_in_class(self.operand(0), self.next_char(text))) {
             self.rewind()
             break
           }
@@ -519,7 +538,8 @@ fn try_match(self : Interpreter, text : String) -> Bool {
         continue
       }
       (SingleLoop, Backtracking)
-      | (NotSingleLoop, Backtracking) | (ClassLoop, Backtracking) => {
+      | (NotSingleLoop, Backtracking)
+      | (ClassLoop, Backtracking) => {
         let text_pos = self.track_pop()
         let i = self.track_pop()
         self.text_pos = text_pos
@@ -592,6 +612,7 @@ fn try_match(self : Interpreter, text : String) -> Bool {
   false
 }
 
+///|
 fn debug_state(self : Interpreter) -> String {
   let buf = @buffer.new()
   let _ = self.prog.output_op(self.op_pos, buf)
@@ -600,5 +621,5 @@ fn debug_state(self : Interpreter) -> String {
   buf.write_string("op_stack: " + self.op_stack.to_string() + "\n")
   buf.write_string("track_stack: " + self.track_stack.to_string() + "\n")
   buf.write_string("run_stack: " + self.run_stack.to_string() + "\n")
-  buf.to_unchecked_string()
+  buf.contents().to_unchecked_string()
 }

--- a/opcode.mbt
+++ b/opcode.mbt
@@ -1,3 +1,4 @@
+///|
 priv enum OpCode {
   Nop
   Stop
@@ -31,6 +32,7 @@ priv enum OpCode {
   GetMark
 } derive(Show)
 
+///|
 fn to_bytecode(self : OpCode) -> Int {
   match self {
     Nop => -1
@@ -64,6 +66,7 @@ fn to_bytecode(self : OpCode) -> Int {
   }
 }
 
+///|
 fn OpCode::from_bytecode(bytecode : Int) -> OpCode {
   match bytecode {
     0 => Stop
@@ -97,7 +100,7 @@ fn OpCode::from_bytecode(bytecode : Int) -> OpCode {
   }
 }
 
-/// Returns true if this operation needs to backtrack.
+///| Returns true if this operation needs to backtrack.
 fn backtrack(self : OpCode) -> Bool {
   match self {
     SingleLoop
@@ -110,8 +113,12 @@ fn backtrack(self : OpCode) -> Bool {
     | BranchMark
     | BranchMarkLazy
     | NullCount
-    | SetCount | BranchCount | BranchCountLazy | SetMark | CaptureMark | Goto =>
-      true
+    | SetCount
+    | BranchCount
+    | BranchCountLazy
+    | SetMark
+    | CaptureMark
+    | Goto => true
     _ => false
   }
 }

--- a/parser.mbt
+++ b/parser.mbt
@@ -1,5 +1,7 @@
+///|
 let max_loop_count = 100_000
 
+///|
 pub(all) type! ParseError {
   InternalParserError
   UnmatchedGroupBegin(pos~ : Int)
@@ -17,6 +19,7 @@ pub(all) type! ParseError {
   GroupMissingParen(pos~ : Int)
 } derive(Eq, Show)
 
+///|
 priv struct Parser {
   pattern : String
   mut pos : Int
@@ -26,6 +29,7 @@ priv struct Parser {
   capture_name_mapping : Map[String, Int]
 }
 
+///|
 fn Parser::new(pattern : String) -> Parser {
   {
     pattern,
@@ -37,45 +41,54 @@ fn Parser::new(pattern : String) -> Parser {
   }
 }
 
+///|
 fn pos(self : Parser) -> Int {
   self.pos
 }
 
+///|
 fn rewind(self : Parser, n : Int) -> Unit {
   self.pos -= n
 }
 
+///|
 fn advance(self : Parser, n : Int) -> Unit {
   self.pos += n
 }
 
+///|
 fn mark(self : Parser) -> Unit {
   self.pos_mark = self.pos
 }
 
+///|
 fn restore(self : Parser) -> Unit {
   self.pos = self.pos_mark
 }
 
+///|
 fn more(self : Parser) -> Bool {
   self.pos < self.pattern.length()
 }
 
+///|
 fn peek(self : Parser) -> Char {
-  if self.more().not() {
+  if not(self.more()) {
     abort("index out of bounds")
   }
   self.pattern[self.pos]
 }
 
+///|
 fn peek_is(self : Parser, expected : Char) -> Bool {
-  if self.more().not() {
+  if not(self.more()) {
     false
   } else {
     self.peek() == expected
   }
 }
 
+///|
 fn check_exist(self : Parser, c : Char) -> Bool {
   self.mark()
   while self.more() {
@@ -89,6 +102,7 @@ fn check_exist(self : Parser, c : Char) -> Bool {
   false
 }
 
+///|
 fn fetch_unsigned_num(self : Parser) -> Int? {
   let num_buf = @buffer.new()
   loop self.peek() {
@@ -101,7 +115,7 @@ fn fetch_unsigned_num(self : Parser) -> Int? {
     }
     _ => break
   }
-  let num_str = num_buf.to_unchecked_string()
+  let num_str = num_buf.contents().to_unchecked_string()
   if num_str == "" {
     return None
   }
@@ -113,6 +127,7 @@ fn fetch_unsigned_num(self : Parser) -> Int? {
   }
 }
 
+///|
 fn parse(self : Parser) -> Ast!ParseError {
   let root = AstNode::new(Capture(index=self.group_index))
   self.group_index += 1
@@ -125,9 +140,10 @@ fn parse(self : Parser) -> Ast!ParseError {
   }
 }
 
+///|
 fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
   let node = self.parse_concat!(in_group)
-  if self.more().not() || (in_group && self.peek_is(')')) {
+  if not(self.more()) || (in_group && self.peek_is(')')) {
     return node
   } else if self.peek_is('|') {
     let alt_node = AstNode::new(Alternate)
@@ -136,7 +152,7 @@ fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
       self.advance(1) // |
       alt_node.add_child(self.parse_concat!(in_group))
     }
-    if in_group.not() && self.more() {
+    if not(in_group) && self.more() {
       raise InternalParserError
     } else {
       alt_node
@@ -146,24 +162,26 @@ fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
   }
 }
 
+///|
 fn parse_concat(self : Parser, in_group : Bool) -> AstNode!ParseError {
   let node = self.parse_node!(in_group)
-  if self.more().not() || self.peek_is('|') || (in_group && self.peek_is(')')) {
+  if not(self.more()) || self.peek_is('|') || (in_group && self.peek_is(')')) {
     node
   } else {
     let concat_node = AstNode::new(Concatenate)
     concat_node.add_child(node)
     while self.more() &&
-          self.peek_is('|').not() &&
-          (in_group && self.peek_is(')')).not() {
+          not(self.peek_is('|')) &&
+          not(in_group && self.peek_is(')')) {
       concat_node.add_child(self.parse_node!(in_group))
     }
     concat_node
   }
 }
 
+///|
 fn parse_node(self : Parser, in_group : Bool) -> AstNode!ParseError {
-  if self.more().not() || (in_group && self.peek_is(')')) {
+  if not(self.more()) || (in_group && self.peek_is(')')) {
     return AstNode::new(Empty)
   }
   let node = match self.peek() {
@@ -206,8 +224,9 @@ fn parse_node(self : Parser, in_group : Bool) -> AstNode!ParseError {
   self.parse_loop!(node)
 }
 
+///|
 fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
-  if self.more().not() {
+  if not(self.more()) {
     return target
   }
   let mut greedy = true
@@ -247,8 +266,9 @@ fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
   }
 }
 
+///|
 fn parse_loop_range(self : Parser) -> (Int, Int?)!ParseError {
-  if self.more().not() {
+  if not(self.more()) {
     raise InvalidLoop(pos=self.pos)
   }
   let min = match self.fetch_unsigned_num() {
@@ -258,7 +278,7 @@ fn parse_loop_range(self : Parser) -> (Int, Int?)!ParseError {
   if min < 0 || min > max_loop_count {
     raise LoopCountOutOfRange(pos=self.pos)
   }
-  if self.more().not() {
+  if not(self.more()) {
     raise InvalidLoop(pos=self.pos)
   }
   let max : Int? = if self.peek_is(',') {
@@ -267,21 +287,22 @@ fn parse_loop_range(self : Parser) -> (Int, Int?)!ParseError {
   } else {
     Some(min)
   }
-  if max.is_empty().not() && (max.unwrap() < 0 || max.unwrap() > max_loop_count) {
+  if not(max.is_empty()) && (max.unwrap() < 0 || max.unwrap() > max_loop_count) {
     raise LoopCountOutOfRange(pos=self.pos)
   }
-  if self.more().not() || self.peek_is('}').not() {
+  if not(self.more()) || not(self.peek_is('}')) {
     raise InvalidLoop(pos=self.pos)
   }
   self.advance(1) // '}'
-  if max.is_empty().not() && min > max.unwrap() {
+  if not(max.is_empty()) && min > max.unwrap() {
     raise LoopMaxCountSmallerThanMinCount(pos=self.pos)
   }
   (min, max)
 }
 
+///|
 fn parse_group(self : Parser) -> AstNode!ParseError {
-  if self.more().not() {
+  if not(self.more()) {
     raise UnmatchedGroupBegin(pos=self.pos)
   }
   let mut capture = true
@@ -307,7 +328,7 @@ fn parse_group(self : Parser) -> AstNode!ParseError {
       _ => ()
     }
   }
-  if self.more().not() || self.peek_is(')') {
+  if not(self.more()) || self.peek_is(')') {
     raise EmptyGroup(pos=self.pos)
   }
   let node = if capture {
@@ -316,27 +337,29 @@ fn parse_group(self : Parser) -> AstNode!ParseError {
     AstNode::new(Group)
   }
   node.add_child(self.parse_expr!(true))
-  if self.more().not() || self.peek_is(')').not() {
+  if not(self.more()) || not(self.peek_is(')')) {
     raise GroupMissingParen(pos=self.pos)
   }
   self.advance(1) // ')'
   node
 }
 
+///|
 fn parse_group_name(self : Parser) -> String!ParseError {
   self.advance(1) // '<'
   let buf = @buffer.new()
-  while self.more() && self.peek_is('>').not() {
+  while self.more() && not(self.peek_is('>')) {
     buf.write_char(self.peek())
     self.advance(1)
   }
-  if self.peek_is('>').not() {
+  if not(self.peek_is('>')) {
     raise UnmatchedGroupName(pos=self.pos)
   }
   self.advance(1) // '>'
-  buf.to_unchecked_string()
+  buf.contents().to_unchecked_string()
 }
 
+///|
 fn parse_class(self : Parser) -> AstNode!ParseError {
   let neg = if self.peek_is('^') {
     self.advance(1)
@@ -347,7 +370,7 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
   let mut first = true
   let char_class = CharClass::new(neg~)
   // Allow ']' and '-' as first char in class
-  while self.more() && (self.peek_is(']').not() || first) {
+  while self.more() && (not(self.peek_is(']')) || first) {
     if (self.peek_is(']') || self.peek_is('-')) && first {
       char_class.add_single(self.peek())
       self.advance(1)
@@ -385,7 +408,7 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
       char_class.add_range(low, high)
     }
   }
-  if self.more().not() || self.peek_is(']').not() {
+  if not(self.more()) || not(self.peek_is(']')) {
     raise ClassMissingBracket(pos=self.pos)
   } else {
     self.advance(1) // ']'
@@ -393,8 +416,9 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
   }
 }
 
+///|
 fn parse_char_class_char(self : Parser) -> Char!ParseError {
-  if self.more().not() {
+  if not(self.more()) {
     raise ClassMissingBracket(pos=self.pos)
   }
   if self.peek_is('\\') {
@@ -405,8 +429,9 @@ fn parse_char_class_char(self : Parser) -> Char!ParseError {
   c
 }
 
+///|
 fn parse_escape(self : Parser) -> AstNode!ParseError {
-  if self.more().not() {
+  if not(self.more()) {
     raise EndPatternAtEscape(pos=self.pos)
   }
   let node : AstNodeInternal = match self.peek() {

--- a/parser_wbtest.mbt
+++ b/parser_wbtest.mbt
@@ -1,3 +1,4 @@
+///|
 fn test_parse(s : String) -> Ast!ParseError {
   Parser::new(s).parse!()
 }

--- a/program.mbt
+++ b/program.mbt
@@ -1,3 +1,4 @@
+///|
 priv struct Program {
   bytecodes : Array[Int]
   classes : Array[CharClass]
@@ -5,14 +6,17 @@ priv struct Program {
   capture_name_mapping : Map[String, Int]
 }
 
+///|
 fn op_code(self : Program, pos : Int) -> OpCode {
   OpCode::from_bytecode(self.bytecodes[pos])
 }
 
+///|
 fn operand(self : Program, pos : Int) -> Int {
   self.bytecodes[pos]
 }
 
+///|
 impl Show for Program with output(self, logger) -> Unit {
   let mut pos = 0
   while pos < self.bytecodes.length() {
@@ -22,11 +26,13 @@ impl Show for Program with output(self, logger) -> Unit {
   }
 }
 
+///|
 fn to_string(self : Program) -> String {
   Show::to_string(self)
 }
 
-fn output_op(self : Program, pos : Int, logger : Logger) -> Int {
+///|
+fn output_op(self : Program, pos : Int, logger : &Logger) -> Int {
   let mut size = 0
   logger.write_string("\{pos} ")
   let opcode = OpCode::from_bytecode(self.bytecodes[pos])
@@ -37,7 +43,11 @@ fn output_op(self : Program, pos : Int, logger : Logger) -> Int {
     }
     Goto
     | BranchLazy
-    | BranchMark | BranchMarkLazy | NullCount | SetCount | CaptureMark => {
+    | BranchMark
+    | BranchMarkLazy
+    | NullCount
+    | SetCount
+    | CaptureMark => {
       let opd = self.bytecodes[pos + 1]
       logger.write_string("\{opcode} \{opd}")
       size = 2
@@ -54,7 +64,11 @@ fn output_op(self : Program, pos : Int, logger : Logger) -> Int {
       size = 2
     }
     SingleRepeat
-    | NotSingleRepeat | SingleLoop | NotSingleLoop | SingleLazy | NotSingleLazy => {
+    | NotSingleRepeat
+    | SingleLoop
+    | NotSingleLoop
+    | SingleLazy
+    | NotSingleLazy => {
       let char = self.bytecodes[pos + 1]
       let opd2 = self.bytecodes[pos + 2]
       logger.write_string("\{opcode} \{char} \{opd2}")

--- a/regexp.mbt
+++ b/regexp.mbt
@@ -1,22 +1,27 @@
+///|
 struct RegExp {
   pattern : String
   prog : Program
 }
 
+///|
 fn RegExp::new(pattern : String) -> RegExp! {
   let ast = Parser::new(pattern).parse!()
   let prog = Emitter::new(ast).emit()
   { pattern, prog }
 }
 
+///|
 pub fn compile(pattern : String) -> RegExp! {
   RegExp::new!(pattern)
 }
 
+///|
 pub fn pattern(self : RegExp) -> String {
   self.pattern
 }
 
+///|
 pub fn matches(
   self : RegExp,
   text : String,

--- a/result.mbt
+++ b/result.mbt
@@ -1,17 +1,21 @@
+///|
 struct MatchResult {
   success : Bool
   captures : Array[String]
   named_captures : Map[String, String]
 } derive(Show)
 
+///|
 pub fn success(self : MatchResult) -> Bool {
   self.success
 }
 
+///|
 pub fn captures(self : MatchResult) -> Array[String] {
   self.captures
 }
 
+///|
 pub fn named_captures(self : MatchResult) -> Map[String, String] {
   self.named_captures
 }


### PR DESCRIPTION
This PR runs `moon fmt` over all the code and removes all deprecation warnings.
I didn't bump the `moon.mod.json` version from `0.3.2` because I didn't know if you prefer to make this `0.3.3` or `0.4.0`.