### PR TITLE
chore: update to moonc v0.1.20250612+600461c34

### DIFF
--- a/src/ast.mbt
+++ b/src/ast.mbt
@@ -4,11 +4,11 @@ priv enum AstNodeInternal {
   Empty
   Single(char~ : Char)
   NotSingle(char~ : Char)
-  Class(class~ : CharClass)
+  Class(clazz~ : CharClass)
   // Multi(~str : String)
   SingleLoop(char~ : Char, min~ : Int, max~ : Int?, greedy~ : Bool)
   NotSingleLoop(char~ : Char, min~ : Int, max~ : Int?, greedy~ : Bool)
-  ClassLoop(class~ : CharClass, min~ : Int, max~ : Int?, greedy~ : Bool)
+  ClassLoop(clazz~ : CharClass, min~ : Int, max~ : Int?, greedy~ : Bool)
   // Backreference(~index : Int)
   BeginOfInput
   EndOfInput
@@ -41,7 +41,7 @@ fn to_string(self : AstNodeInternal) -> String {
     Empty => "Empty"
     Single(char~) => "Single " + char.to_int().to_string()
     NotSingle(char~) => "NotSingle " + char.to_int().to_string()
-    Class(class~) => "Class " + class.to_string()
+    Class(clazz~) => "Class " + clazz.to_string()
     SingleLoop(char~, min~, max~, greedy~) =>
       "SingleLoop " +
       greedy_str(greedy) +
@@ -52,11 +52,11 @@ fn to_string(self : AstNodeInternal) -> String {
       greedy_str(greedy) +
       range_str(min, max) +
       char.to_int().to_string()
-    ClassLoop(class~, min~, max~, greedy~) =>
+    ClassLoop(clazz~, min~, max~, greedy~) =>
       "ClassLoop " +
       greedy_str(greedy) +
       range_str(min, max) +
-      class.to_string()
+      clazz.to_string()
     BeginOfInput => "BeginOfLine"
     EndOfInput => "EndOfLine"
     Alternate => "Alternate"

--- a/src/emitter.mbt
+++ b/src/emitter.mbt
@@ -154,9 +154,9 @@ fn emit_fragment(
     (Group, _) => ()
     (Single(char~), _) => self.emit_1(Single, char.to_int())
     (NotSingle(char~), _) => self.emit_1(NotSingle, char.to_int())
-    (Class(class~), _) => {
+    (Class(clazz~), _) => {
       let idx = self.classes.length()
-      self.classes.push(class)
+      self.classes.push(clazz)
       self.emit_1(Class, idx)
     }
     (SingleLoop(char~, min~, max~, greedy~), _) => {
@@ -181,9 +181,9 @@ fn emit_fragment(
         None => self.emit_2(opcode, opd, @int.max_value)
       }
     }
-    (ClassLoop(class~, min~, max~, greedy~), _) => {
+    (ClassLoop(clazz~, min~, max~, greedy~), _) => {
       let idx = self.classes.length()
-      self.classes.push(class)
+      self.classes.push(clazz)
       if min > 0 {
         self.emit_2(ClassRepeat, idx, min)
       }

--- a/src/emitter_wbtest.mbt
+++ b/src/emitter_wbtest.mbt
@@ -5,8 +5,8 @@ fn test_emit(ast : Ast) -> Program {
 
 ///|
 test "should emit single" {
-  inspect!(
-    test_parse!("a") |> test_emit(),
+  inspect(
+    test_parse("a") |> test_emit(),
     content=
       #|0 BranchLazy 7
       #|2 SetMark
@@ -20,8 +20,8 @@ test "should emit single" {
 
 ///|
 test "should emit concat" {
-  inspect!(
-    test_parse!("abc") |> test_emit(),
+  inspect(
+    test_parse("abc") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -37,8 +37,8 @@ test "should emit concat" {
 
 ///|
 test "should emit alt" {
-  inspect!(
-    test_parse!("a|b|c") |> test_emit(),
+  inspect(
+    test_parse("a|b|c") |> test_emit(),
     content=
       #|0 BranchLazy 19
       #|2 SetMark
@@ -58,8 +58,8 @@ test "should emit alt" {
 
 ///|
 test "should emit loop" {
-  inspect!(
-    test_parse!("a*") |> test_emit(),
+  inspect(
+    test_parse("a*") |> test_emit(),
     content=
       #|0 BranchLazy 8
       #|2 SetMark
@@ -69,8 +69,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a+") |> test_emit(),
+  inspect(
+    test_parse("a+") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -81,8 +81,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a?") |> test_emit(),
+  inspect(
+    test_parse("a?") |> test_emit(),
     content=
       #|0 BranchLazy 8
       #|2 SetMark
@@ -92,8 +92,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a{3}") |> test_emit(),
+  inspect(
+    test_parse("a{3}") |> test_emit(),
     content=
       #|0 BranchLazy 8
       #|2 SetMark
@@ -103,8 +103,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a{1,3}") |> test_emit(),
+  inspect(
+    test_parse("a{1,3}") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -115,8 +115,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a{1,}") |> test_emit(),
+  inspect(
+    test_parse("a{1,}") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -127,8 +127,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a*?") |> test_emit(),
+  inspect(
+    test_parse("a*?") |> test_emit(),
     content=
       #|0 BranchLazy 8
       #|2 SetMark
@@ -138,8 +138,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a+?") |> test_emit(),
+  inspect(
+    test_parse("a+?") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -150,8 +150,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a??") |> test_emit(),
+  inspect(
+    test_parse("a??") |> test_emit(),
     content=
       #|0 BranchLazy 8
       #|2 SetMark
@@ -161,8 +161,8 @@ test "should emit loop" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a{1,2}?") |> test_emit(),
+  inspect(
+    test_parse("a{1,2}?") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -177,8 +177,8 @@ test "should emit loop" {
 
 ///|
 test "should emit class" {
-  inspect!(
-    test_parse!("[abc]") |> test_emit(),
+  inspect(
+    test_parse("[abc]") |> test_emit(),
     content=
       #|0 BranchLazy 7
       #|2 SetMark
@@ -188,8 +188,8 @@ test "should emit class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[^abc]") |> test_emit(),
+  inspect(
+    test_parse("[^abc]") |> test_emit(),
     content=
       #|0 BranchLazy 7
       #|2 SetMark
@@ -199,8 +199,8 @@ test "should emit class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[a-zA-Z0-9]") |> test_emit(),
+  inspect(
+    test_parse("[a-zA-Z0-9]") |> test_emit(),
     content=
       #|0 BranchLazy 7
       #|2 SetMark
@@ -214,8 +214,8 @@ test "should emit class" {
 
 ///|
 test "should emit group" {
-  inspect!(
-    test_parse!("(abc)") |> test_emit(),
+  inspect(
+    test_parse("(abc)") |> test_emit(),
     content=
       #|0 BranchLazy 14
       #|2 SetMark
@@ -229,8 +229,8 @@ test "should emit group" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("((a)bc)") |> test_emit(),
+  inspect(
+    test_parse("((a)bc)") |> test_emit(),
     content=
       #|0 BranchLazy 17
       #|2 SetMark
@@ -246,8 +246,8 @@ test "should emit group" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("((a)|(b))") |> test_emit(),
+  inspect(
+    test_parse("((a)|(b))") |> test_emit(),
     content=
       #|0 BranchLazy 22
       #|2 SetMark
@@ -270,8 +270,8 @@ test "should emit group" {
 
 ///|
 test "should emit non-capturing group" {
-  inspect!(
-    test_parse!("(?:abc)") |> test_emit(),
+  inspect(
+    test_parse("(?:abc)") |> test_emit(),
     content=
       #|0 BranchLazy 11
       #|2 SetMark
@@ -287,8 +287,8 @@ test "should emit non-capturing group" {
 
 ///|
 test "should emit named group" {
-  inspect!(
-    test_parse!("(?<group1>abc)") |> test_emit(),
+  inspect(
+    test_parse("(?<group1>abc)") |> test_emit(),
     content=
       #|0 BranchLazy 14
       #|2 SetMark
@@ -306,8 +306,8 @@ test "should emit named group" {
 
 ///|
 test "should emit common pattern" {
-  let ast = test_parse!("^([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$")
-  inspect!(
+  let ast = test_parse("^([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$")
+  inspect(
     test_emit(ast),
     content=
       #|0 BranchLazy 35

--- a/src/interpreter.mbt
+++ b/src/interpreter.mbt
@@ -120,7 +120,7 @@ fn chars_remain(self : Interpreter) -> Int {
 ///|
 fn next_char(self : Interpreter, text : String) -> Int {
   self.text_pos += 1
-  text[self.text_pos - 1].to_int()
+  text.charcode_at(self.text_pos - 1)
 }
 
 ///|
@@ -130,8 +130,8 @@ fn rewind(self : Interpreter) -> Unit {
 
 ///|
 fn char_in_class(self : Interpreter, class_idx : Int, char : Int) -> Bool {
-  let class = self.prog.classes[class_idx]
-  class.contains(char)
+  let clazz = self.prog.classes[class_idx]
+  clazz.contains(char)
 }
 
 ///|
@@ -594,8 +594,8 @@ fn try_match(self : Interpreter, text : String) -> Bool {
         let text_pos = self.track_pop()
         self.text_pos = text_pos
         let count = self.track_pop()
-        let class = self.prog.classes[self.operand(0)]
-        if class.contains(self.next_char(text)) {
+        let clazz = self.prog.classes[self.operand(0)]
+        if clazz.contains(self.next_char(text)) {
           if count > 0 {
             self.op_push()
             self.track_push(count - 1)

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -2,7 +2,7 @@
 let max_loop_count = 100_000
 
 ///|
-pub(all) type! ParseError {
+pub(all) suberror ParseError {
   InternalParserError
   UnmatchedGroupBegin(pos~ : Int)
   UnmatchedGroupEnd(pos~ : Int)
@@ -76,7 +76,7 @@ fn peek(self : Parser) -> Char {
   if not(self.more()) {
     abort("index out of bounds")
   }
-  self.pattern[self.pos]
+  self.pattern.charcode_at(self.pos).unsafe_to_char()
 }
 
 ///|
@@ -120,7 +120,7 @@ fn fetch_unsigned_num(self : Parser) -> Int? {
     return None
   }
   try {
-    let num = @strconv.parse_int!(num_str)
+    let num = @strconv.parse_int(num_str)
     Some(num)
   } catch {
     _ => None
@@ -128,11 +128,11 @@ fn fetch_unsigned_num(self : Parser) -> Int? {
 }
 
 ///|
-fn parse(self : Parser) -> Ast!ParseError {
+fn parse(self : Parser) -> Ast raise ParseError {
   let root = AstNode::new(Capture(index=self.group_index))
   self.group_index += 1
   self.capture_num += 1
-  root.add_child(self.parse_expr!(false))
+  root.add_child(self.parse_expr(false))
   {
     root,
     capture_num: self.capture_num,
@@ -141,8 +141,8 @@ fn parse(self : Parser) -> Ast!ParseError {
 }
 
 ///|
-fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
-  let node = self.parse_concat!(in_group)
+fn parse_expr(self : Parser, in_group : Bool) -> AstNode raise ParseError {
+  let node = self.parse_concat(in_group)
   if not(self.more()) || (in_group && self.peek_is(')')) {
     return node
   } else if self.peek_is('|') {
@@ -154,7 +154,7 @@ fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
         alt_node.add_child(AstNode::new(Empty))
         continue
       }
-      alt_node.add_child(self.parse_concat!(in_group))
+      alt_node.add_child(self.parse_concat(in_group))
     }
     if not(in_group) && self.more() {
       raise InternalParserError
@@ -167,8 +167,8 @@ fn parse_expr(self : Parser, in_group : Bool) -> AstNode!ParseError {
 }
 
 ///|
-fn parse_concat(self : Parser, in_group : Bool) -> AstNode!ParseError {
-  let node = self.parse_node!(in_group)
+fn parse_concat(self : Parser, in_group : Bool) -> AstNode raise ParseError {
+  let node = self.parse_node(in_group)
   if not(self.more()) || self.peek_is('|') || (in_group && self.peek_is(')')) {
     node
   } else {
@@ -177,14 +177,14 @@ fn parse_concat(self : Parser, in_group : Bool) -> AstNode!ParseError {
     while self.more() &&
           not(self.peek_is('|')) &&
           not(in_group && self.peek_is(')')) {
-      concat_node.add_child(self.parse_node!(in_group))
+      concat_node.add_child(self.parse_node(in_group))
     }
     concat_node
   }
 }
 
 ///|
-fn parse_node(self : Parser, in_group : Bool) -> AstNode!ParseError {
+fn parse_node(self : Parser, in_group : Bool) -> AstNode raise ParseError {
   if not(self.more()) || (in_group && self.peek_is(')')) {
     return AstNode::new(Empty)
   }
@@ -207,29 +207,29 @@ fn parse_node(self : Parser, in_group : Bool) -> AstNode!ParseError {
     }
     '(' => {
       self.advance(1)
-      self.parse_group!()
+      self.parse_group()
     }
     ')' => raise UnmatchedGroupEnd(pos=self.pos)
     '[' => {
       self.advance(1)
-      self.parse_class!()
+      self.parse_class()
     }
     ']' => raise UnmatchedCharClassEnd(pos=self.pos)
     '*' | '+' | '?' | '{' | '}' => raise UnspecifiedLoopTarget(pos=self.pos)
     '\\' => {
       self.advance(1)
-      self.parse_escape!()
+      self.parse_escape()
     }
     _ as char => {
       self.advance(1)
       AstNode::new(Single(char~))
     }
   }
-  self.parse_loop!(node)
+  self.parse_loop(node)
 }
 
 ///|
-fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
+fn parse_loop(self : Parser, target : AstNode) -> AstNode raise ParseError {
   if not(self.more()) {
     return target
   }
@@ -248,7 +248,7 @@ fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
     }
     '{' => {
       self.advance(1)
-      let range = self.parse_loop_range!()
+      let range = self.parse_loop_range()
       min = range.0
       max = range.1
     }
@@ -261,7 +261,7 @@ fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
   match target.internal {
     Single(char~) => AstNode::new(SingleLoop(char~, min~, max~, greedy~))
     NotSingle(char~) => AstNode::new(NotSingleLoop(char~, min~, max~, greedy~))
-    Class(class~) => AstNode::new(ClassLoop(class~, min~, max~, greedy~))
+    Class(clazz~) => AstNode::new(ClassLoop(clazz~, min~, max~, greedy~))
     _ => {
       let node = AstNode::new(Loop(min~, max~, greedy~))
       node.add_child(target)
@@ -271,7 +271,7 @@ fn parse_loop(self : Parser, target : AstNode) -> AstNode!ParseError {
 }
 
 ///|
-fn parse_loop_range(self : Parser) -> (Int, Int?)!ParseError {
+fn parse_loop_range(self : Parser) -> (Int, Int?) raise ParseError {
   if not(self.more()) {
     raise InvalidLoop(pos=self.pos)
   }
@@ -305,7 +305,7 @@ fn parse_loop_range(self : Parser) -> (Int, Int?)!ParseError {
 }
 
 ///|
-fn parse_group(self : Parser) -> AstNode!ParseError {
+fn parse_group(self : Parser) -> AstNode raise ParseError {
   if not(self.more()) {
     raise UnmatchedGroupBegin(pos=self.pos)
   }
@@ -323,7 +323,7 @@ fn parse_group(self : Parser) -> AstNode!ParseError {
         self.advance(1) // ':'
       }
       '<' => {
-        name = self.parse_group_name!()
+        name = self.parse_group_name()
         if name == "" {
           raise EmptyGroupName(pos=self.pos)
         }
@@ -340,7 +340,7 @@ fn parse_group(self : Parser) -> AstNode!ParseError {
   } else {
     AstNode::new(Group)
   }
-  node.add_child(self.parse_expr!(true))
+  node.add_child(self.parse_expr(true))
   if not(self.more()) || not(self.peek_is(')')) {
     raise GroupMissingParen(pos=self.pos)
   }
@@ -349,7 +349,7 @@ fn parse_group(self : Parser) -> AstNode!ParseError {
 }
 
 ///|
-fn parse_group_name(self : Parser) -> String!ParseError {
+fn parse_group_name(self : Parser) -> String raise ParseError {
   self.advance(1) // '<'
   let buf = @buffer.new()
   while self.more() && not(self.peek_is('>')) {
@@ -364,7 +364,7 @@ fn parse_group_name(self : Parser) -> String!ParseError {
 }
 
 ///|
-fn parse_class(self : Parser) -> AstNode!ParseError {
+fn parse_class(self : Parser) -> AstNode raise ParseError {
   let neg = if self.peek_is('^') {
     self.advance(1)
     true
@@ -398,7 +398,7 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
       }
       self.advance(1)
     } else {
-      let low = self.parse_char_class_char!()
+      let low = self.parse_char_class_char()
       let mut high = low
       if self.more() && self.peek_is('-') {
         self.advance(1) // '-'
@@ -406,7 +406,7 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
           // '-' is the last char
           self.rewind(1)
         } else {
-          high = self.parse_char_class_char!()
+          high = self.parse_char_class_char()
         }
       }
       char_class.add_range(low, high)
@@ -416,12 +416,12 @@ fn parse_class(self : Parser) -> AstNode!ParseError {
     raise ClassMissingBracket(pos=self.pos)
   } else {
     self.advance(1) // ']'
-    AstNode::new(Class(class=char_class))
+    AstNode::new(Class(clazz=char_class))
   }
 }
 
 ///|
-fn parse_char_class_char(self : Parser) -> Char!ParseError {
+fn parse_char_class_char(self : Parser) -> Char raise ParseError {
   if not(self.more()) {
     raise ClassMissingBracket(pos=self.pos)
   }
@@ -434,17 +434,59 @@ fn parse_char_class_char(self : Parser) -> Char!ParseError {
 }
 
 ///|
-fn parse_escape(self : Parser) -> AstNode!ParseError {
+fn parse_escape(self : Parser) -> AstNode raise ParseError {
   if not(self.more()) {
     raise EndPatternAtEscape(pos=self.pos)
   }
   let node : AstNodeInternal = match self.peek() {
-    'd' => Class(class=CharClass::new()..add_category(Digit))
-    'D' => Class(class=CharClass::new()..add_category(NotDigit))
-    's' => Class(class=CharClass::new()..add_category(Space))
-    'S' => Class(class=CharClass::new()..add_category(NotSpace))
-    'w' => Class(class=CharClass::new()..add_category(Word))
-    'W' => Class(class=CharClass::new()..add_category(NotWord))
+    'd' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(Digit)
+          clazz
+        },
+      )
+    'D' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(NotDigit)
+          clazz
+        },
+      )
+    's' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(Space)
+          clazz
+        },
+      )
+    'S' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(NotSpace)
+          clazz
+        },
+      )
+    'w' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(Word)
+          clazz
+        },
+      )
+    'W' =>
+      Class(
+        clazz={
+          let clazz = CharClass::new()
+          clazz.add_category(NotWord)
+          clazz
+        },
+      )
     't' => Single(char='\t')
     'r' => Single(char='\r')
     'n' => Single(char='\n')

--- a/src/parser_wbtest.mbt
+++ b/src/parser_wbtest.mbt
@@ -1,13 +1,13 @@
 ///|
-fn test_parse(s : String) -> Ast!ParseError {
-  Parser::new(s).parse!()
+fn test_parse(s : String) -> Ast raise ParseError {
+  Parser::new(s).parse()
 }
 
 // #region single
 ///|
 test "should parse single char" {
-  inspect!(
-    test_parse!("a"),
+  inspect(
+    test_parse("a"),
     content=
       #|
       #|Number of captures: 1
@@ -22,8 +22,8 @@ test "should parse single char" {
 
 ///|
 test "should parse any char" {
-  inspect!(
-    test_parse!("."),
+  inspect(
+    test_parse("."),
     content=
       #|
       #|Number of captures: 1
@@ -38,8 +38,8 @@ test "should parse any char" {
 
 ///|
 test "should parse escape" {
-  inspect!(
-    test_parse!("\\s"),
+  inspect(
+    test_parse("\\s"),
     content=
       #|
       #|Number of captures: 1
@@ -50,8 +50,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\S"),
+  inspect(
+    test_parse("\\S"),
     content=
       #|
       #|Number of captures: 1
@@ -62,8 +62,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\d"),
+  inspect(
+    test_parse("\\d"),
     content=
       #|
       #|Number of captures: 1
@@ -74,8 +74,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\D"),
+  inspect(
+    test_parse("\\D"),
     content=
       #|
       #|Number of captures: 1
@@ -86,8 +86,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\w"),
+  inspect(
+    test_parse("\\w"),
     content=
       #|
       #|Number of captures: 1
@@ -98,8 +98,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\W"),
+  inspect(
+    test_parse("\\W"),
     content=
       #|
       #|Number of captures: 1
@@ -110,8 +110,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\n"),
+  inspect(
+    test_parse("\\n"),
     content=
       #|
       #|Number of captures: 1
@@ -122,8 +122,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\r"),
+  inspect(
+    test_parse("\\r"),
     content=
       #|
       #|Number of captures: 1
@@ -134,8 +134,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\f"),
+  inspect(
+    test_parse("\\f"),
     content=
       #|
       #|Number of captures: 1
@@ -146,8 +146,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\v"),
+  inspect(
+    test_parse("\\v"),
     content=
       #|
       #|Number of captures: 1
@@ -158,8 +158,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\t"),
+  inspect(
+    test_parse("\\t"),
     content=
       #|
       #|Number of captures: 1
@@ -170,8 +170,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\*"),
+  inspect(
+    test_parse("\\*"),
     content=
       #|
       #|Number of captures: 1
@@ -189,8 +189,8 @@ test "should parse escape" {
 // #region concat
 ///|
 test "should parse concat" {
-  inspect!(
-    test_parse!("abc"),
+  inspect(
+    test_parse("abc"),
     content=
       #|
       #|Number of captures: 1
@@ -210,8 +210,8 @@ test "should parse concat" {
 // #region alt
 ///|
 test "should parse alt" {
-  inspect!(
-    test_parse!("a|b|c"),
+  inspect(
+    test_parse("a|b|c"),
     content=
       #|
       #|Number of captures: 1
@@ -225,8 +225,8 @@ test "should parse alt" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a||b"),
+  inspect(
+    test_parse("a||b"),
     content=
       #|
       #|Number of captures: 1
@@ -246,8 +246,8 @@ test "should parse alt" {
 // #region repeat
 ///|
 test "should parse star" {
-  inspect!(
-    test_parse!("a*"),
+  inspect(
+    test_parse("a*"),
     content=
       #|
       #|Number of captures: 1
@@ -262,8 +262,8 @@ test "should parse star" {
 
 ///|
 test "should parse plus" {
-  inspect!(
-    test_parse!("a+"),
+  inspect(
+    test_parse("a+"),
     content=
       #|
       #|Number of captures: 1
@@ -278,8 +278,8 @@ test "should parse plus" {
 
 ///|
 test "should parse quest" {
-  inspect!(
-    test_parse!("a?"),
+  inspect(
+    test_parse("a?"),
     content=
       #|
       #|Number of captures: 1
@@ -294,8 +294,8 @@ test "should parse quest" {
 
 ///|
 test "should parse exact loop" {
-  inspect!(
-    test_parse!("a{2}"),
+  inspect(
+    test_parse("a{2}"),
     content=
       #|
       #|Number of captures: 1
@@ -310,8 +310,8 @@ test "should parse exact loop" {
 
 ///|
 test "should parse loop [min, max]" {
-  inspect!(
-    test_parse!("a{1,2}"),
+  inspect(
+    test_parse("a{1,2}"),
     content=
       #|
       #|Number of captures: 1
@@ -326,8 +326,8 @@ test "should parse loop [min, max]" {
 
 ///|
 test "should parse loop [min, infinity]" {
-  inspect!(
-    test_parse!("a{0,}"),
+  inspect(
+    test_parse("a{0,}"),
     content=
       #|
       #|Number of captures: 1
@@ -342,8 +342,8 @@ test "should parse loop [min, infinity]" {
 
 ///|
 test "should parse non-greedy" {
-  inspect!(
-    test_parse!("a*?"),
+  inspect(
+    test_parse("a*?"),
     content=
       #|
       #|Number of captures: 1
@@ -354,8 +354,8 @@ test "should parse non-greedy" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a+?"),
+  inspect(
+    test_parse("a+?"),
     content=
       #|
       #|Number of captures: 1
@@ -366,8 +366,8 @@ test "should parse non-greedy" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a??"),
+  inspect(
+    test_parse("a??"),
     content=
       #|
       #|Number of captures: 1
@@ -378,8 +378,8 @@ test "should parse non-greedy" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("a{0,2}?"),
+  inspect(
+    test_parse("a{0,2}?"),
     content=
       #|
       #|Number of captures: 1
@@ -394,17 +394,17 @@ test "should parse non-greedy" {
 
 ///|
 test "throws on invalid loop" {
-  inspect!(test_parse?("a{,1}"), content="Err(InvalidLoop(pos=2))")
-  inspect!(test_parse?("a{0,1"), content="Err(InvalidLoop(pos=5))")
-  inspect!(test_parse?("a{}"), content="Err(InvalidLoop(pos=2))")
+  inspect(try? test_parse("a{,1}"), content="Err(InvalidLoop(pos=2))")
+  inspect(try? test_parse("a{0,1"), content="Err(InvalidLoop(pos=5))")
+  inspect(try? test_parse("a{}"), content="Err(InvalidLoop(pos=2))")
 }
 // #endregion
 
 // #region class
 ///|
 test "should parse class" {
-  inspect!(
-    test_parse!("[abc]"),
+  inspect(
+    test_parse("[abc]"),
     content=
       #|
       #|Number of captures: 1
@@ -419,8 +419,8 @@ test "should parse class" {
 
 ///|
 test "should parse range class" {
-  inspect!(
-    test_parse!("[a-z]"),
+  inspect(
+    test_parse("[a-z]"),
     content=
       #|
       #|Number of captures: 1
@@ -431,8 +431,8 @@ test "should parse range class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[a-zA-Z]"),
+  inspect(
+    test_parse("[a-zA-Z]"),
     content=
       #|
       #|Number of captures: 1
@@ -443,8 +443,8 @@ test "should parse range class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[0-9]"),
+  inspect(
+    test_parse("[0-9]"),
     content=
       #|
       #|Number of captures: 1
@@ -459,8 +459,8 @@ test "should parse range class" {
 
 ///|
 test "should parse negated class" {
-  inspect!(
-    test_parse!("[^abc]"),
+  inspect(
+    test_parse("[^abc]"),
     content=
       #|
       #|Number of captures: 1
@@ -475,8 +475,8 @@ test "should parse negated class" {
 
 ///|
 test "should parse escape class" {
-  inspect!(
-    test_parse!("[A-Za-z\\s]"),
+  inspect(
+    test_parse("[A-Za-z\\s]"),
     content=
       #|
       #|Number of captures: 1
@@ -487,8 +487,8 @@ test "should parse escape class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[\\D1-3]"),
+  inspect(
+    test_parse("[\\D1-3]"),
     content=
       #|
       #|Number of captures: 1
@@ -499,8 +499,8 @@ test "should parse escape class" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("[\\f\\v]"),
+  inspect(
+    test_parse("[\\f\\v]"),
     content=
       #|
       #|Number of captures: 1
@@ -515,15 +515,15 @@ test "should parse escape class" {
 
 ///|
 test "throws on unclosed class" {
-  inspect!(test_parse?("[abc"), content="Err(ClassMissingBracket(pos=4))")
+  inspect(try? test_parse("[abc"), content="Err(ClassMissingBracket(pos=4))")
 }
 // #endregion
 
 // #region group
 ///|
 test "should parse group" {
-  inspect!(
-    test_parse!("(a)"),
+  inspect(
+    test_parse("(a)"),
     content=
       #|
       #|Number of captures: 2
@@ -535,8 +535,8 @@ test "should parse group" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("(a)(b)"),
+  inspect(
+    test_parse("(a)(b)"),
     content=
       #|
       #|Number of captures: 3
@@ -555,8 +555,8 @@ test "should parse group" {
 
 ///|
 test "should parse nested group" {
-  inspect!(
-    test_parse!("((a)bc)"),
+  inspect(
+    test_parse("((a)bc)"),
     content=
       #|
       #|Number of captures: 3
@@ -576,8 +576,8 @@ test "should parse nested group" {
 
 ///|
 test "should parse nested group concat" {
-  inspect!(
-    test_parse!("((a)(b))"),
+  inspect(
+    test_parse("((a)(b))"),
     content=
       #|
       #|Number of captures: 4
@@ -597,8 +597,8 @@ test "should parse nested group concat" {
 
 ///|
 test "should parse nested group alt" {
-  inspect!(
-    test_parse!("((a)|bc)"),
+  inspect(
+    test_parse("((a)|bc)"),
     content=
       #|
       #|Number of captures: 3
@@ -615,8 +615,8 @@ test "should parse nested group alt" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("((a)|(b))"),
+  inspect(
+    test_parse("((a)|(b))"),
     content=
       #|
       #|Number of captures: 4
@@ -636,8 +636,8 @@ test "should parse nested group alt" {
 
 ///|
 test "should parse non-capturing group" {
-  inspect!(
-    test_parse!("(?:a)"),
+  inspect(
+    test_parse("(?:a)"),
     content=
       #|
       #|Number of captures: 1
@@ -653,8 +653,8 @@ test "should parse non-capturing group" {
 
 ///|
 test "should parse named group" {
-  inspect!(
-    test_parse!("(?<group1>a)"),
+  inspect(
+    test_parse("(?<group1>a)"),
     content=
       #|
       #|Number of captures: 2
@@ -670,25 +670,25 @@ test "should parse named group" {
 
 ///|
 test "throws on unclosed group" {
-  inspect!(test_parse?("(abc"), content="Err(GroupMissingParen(pos=4))")
+  inspect(try? test_parse("(abc"), content="Err(GroupMissingParen(pos=4))")
 }
 
 ///|
 test "throws on empty group" {
-  inspect!(test_parse?("()"), content="Err(EmptyGroup(pos=1))")
+  inspect(try? test_parse("()"), content="Err(EmptyGroup(pos=1))")
 }
 
 ///|
 test "throws on empty group name" {
-  inspect!(test_parse?("(?<>abc)"), content="Err(EmptyGroupName(pos=4))")
+  inspect(try? test_parse("(?<>abc)"), content="Err(EmptyGroupName(pos=4))")
 }
 // #endregion
 
 // #region escape
 ///|
 test "should parse escape" {
-  inspect!(
-    test_parse!("\\*"),
+  inspect(
+    test_parse("\\*"),
     content=
       #|
       #|Number of captures: 1
@@ -699,8 +699,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\+"),
+  inspect(
+    test_parse("\\+"),
     content=
       #|
       #|Number of captures: 1
@@ -711,8 +711,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\?"),
+  inspect(
+    test_parse("\\?"),
     content=
       #|
       #|Number of captures: 1
@@ -723,8 +723,8 @@ test "should parse escape" {
       #|
     ,
   )
-  inspect!(
-    test_parse!("\\a"),
+  inspect(
+    test_parse("\\a"),
     content=
       #|
       #|Number of captures: 1
@@ -741,8 +741,8 @@ test "should parse escape" {
 // #region common
 ///|
 test "should parse common regexp" {
-  inspect!(
-    test_parse!("^([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$"),
+  inspect(
+    test_parse("^([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$"),
     content=
       #|
       #|Number of captures: 3

--- a/src/program.mbt
+++ b/src/program.mbt
@@ -54,8 +54,8 @@ fn output_op(self : Program, pos : Int, logger : &Logger) -> Int {
     }
     Class => {
       let class_idx = self.bytecodes[pos + 1]
-      let class = self.classes[class_idx]
-      logger.write_string("\{opcode} \{class}")
+      let clazz = self.classes[class_idx]
+      logger.write_string("\{opcode} \{clazz}")
       size = 2
     }
     SingleRepeat
@@ -77,9 +77,9 @@ fn output_op(self : Program, pos : Int, logger : &Logger) -> Int {
     }
     ClassRepeat | ClassLoop | ClassLazy => {
       let class_idx = self.bytecodes[pos + 1]
-      let class = self.classes[class_idx]
+      let clazz = self.classes[class_idx]
       let opd2 = self.bytecodes[pos + 2]
-      logger.write_string("\{opcode} \{class} \{opd2}")
+      logger.write_string("\{opcode} \{clazz} \{opd2}")
       size = 3
     }
   }

--- a/src/regexp.mbt
+++ b/src/regexp.mbt
@@ -5,15 +5,15 @@ struct RegExp {
 }
 
 ///|
-fn RegExp::new(pattern : String) -> RegExp! {
-  let ast = Parser::new(pattern).parse!()
+fn RegExp::new(pattern : String) -> RegExp raise {
+  let ast = Parser::new(pattern).parse()
   let prog = Emitter::new(ast).emit()
   { pattern, prog }
 }
 
 ///|
-pub fn compile(pattern : String) -> RegExp! {
-  RegExp::new!(pattern)
+pub fn compile(pattern : String) -> RegExp raise {
+  RegExp::new(pattern)
 }
 
 ///|
@@ -26,7 +26,7 @@ pub fn matches(
   self : RegExp,
   text : String,
   start~ : Int = 0,
-  end~ : Int = text.length()
+  end? : Int
 ) -> MatchResult {
-  Interpreter::new(self.prog).scan(text, start, end)
+  Interpreter::new(self.prog).scan(text, start, end.or(text.length()))
 }

--- a/src/regexp.mbti
+++ b/src/regexp.mbti
@@ -3,9 +3,9 @@ package "yj-qin/regexp"
 // Values
 fn captures(MatchResult) -> Array[String]
 
-fn compile(String) -> RegExp!
+fn compile(String) -> RegExp raise
 
-fn matches(RegExp, String, start~ : Int = .., end~ : Int = ..) -> MatchResult
+fn matches(RegExp, String, start~ : Int = .., end? : Int) -> MatchResult
 
 fn named_captures(MatchResult) -> Map[String, String]
 
@@ -15,14 +15,12 @@ fn success(MatchResult) -> Bool
 
 // Types and methods
 type MatchResult
-impl MatchResult {
-  captures(Self) -> Array[String]
-  named_captures(Self) -> Map[String, String]
-  success(Self) -> Bool
-}
+fn MatchResult::captures(Self) -> Array[String]
+fn MatchResult::named_captures(Self) -> Map[String, String]
+fn MatchResult::success(Self) -> Bool
 impl Show for MatchResult
 
-pub(all) type! ParseError {
+pub(all) suberror ParseError {
   InternalParserError
   UnmatchedGroupBegin(pos~ : Int)
   UnmatchedGroupEnd(pos~ : Int)
@@ -42,10 +40,8 @@ impl Eq for ParseError
 impl Show for ParseError
 
 type RegExp
-impl RegExp {
-  matches(Self, String, start~ : Int = .., end~ : Int = ..) -> MatchResult
-  pattern(Self) -> String
-}
+fn RegExp::matches(Self, String, start~ : Int = .., end? : Int) -> MatchResult
+fn RegExp::pattern(Self) -> String
 
 // Type aliases
 

--- a/src/regexp_test.mbt
+++ b/src/regexp_test.mbt
@@ -1,13 +1,13 @@
 ///|
 test "should match single" {
-  inspect!(
-    @regexp.compile!("a").matches("abc"),
+  inspect(
+    @regexp.compile("a").matches("abc"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("d").matches("abc"),
+  inspect(
+    @regexp.compile("d").matches("abc"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -16,104 +16,104 @@ test "should match single" {
 
 ///|
 test "should match escape" {
-  inspect!(
-    @regexp.compile!("\\d").matches("123"),
+  inspect(
+    @regexp.compile("\\d").matches("123"),
     content=
       #|{success: true, captures: ["1"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\d").matches("abc"),
+  inspect(
+    @regexp.compile("\\d").matches("abc"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\D").matches("abc"),
+  inspect(
+    @regexp.compile("\\D").matches("abc"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\D").matches("123"),
+  inspect(
+    @regexp.compile("\\D").matches("123"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\w").matches("abc"),
+  inspect(
+    @regexp.compile("\\w").matches("abc"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\w").matches(" "),
+  inspect(
+    @regexp.compile("\\w").matches(" "),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\W").matches(" "),
+  inspect(
+    @regexp.compile("\\W").matches(" "),
     content=
       #|{success: true, captures: [" "], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\W").matches("abc"),
+  inspect(
+    @regexp.compile("\\W").matches("abc"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\s").matches(" "),
+  inspect(
+    @regexp.compile("\\s").matches(" "),
     content=
       #|{success: true, captures: [" "], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\s").matches("123"),
+  inspect(
+    @regexp.compile("\\s").matches("123"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\S").matches("123"),
+  inspect(
+    @regexp.compile("\\S").matches("123"),
     content=
       #|{success: true, captures: ["1"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\S").matches(" "),
+  inspect(
+    @regexp.compile("\\S").matches(" "),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\n").matches("a\nb"),
+  inspect(
+    @regexp.compile("\\n").matches("a\nb"),
     content=
       #|{success: true, captures: ["\n"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\r").matches("a\rb"),
+  inspect(
+    @regexp.compile("\\r").matches("a\rb"),
     content=
       #|{success: true, captures: ["\r"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\t").matches("a\tb"),
+  inspect(
+    @regexp.compile("\\t").matches("a\tb"),
     content=
       #|{success: true, captures: ["\t"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\v").matches("a\u000Bb"),
+  inspect(
+    @regexp.compile("\\v").matches("a\u000Bb"),
     content=
       #|{success: true, captures: ["\u{0b}"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("\\f").matches("a\u000Cb"),
+  inspect(
+    @regexp.compile("\\f").matches("a\u000Cb"),
     content=
       #|{success: true, captures: ["\u{0c}"], named_captures: {}}
     ,
@@ -122,14 +122,14 @@ test "should match escape" {
 
 ///|
 test "should match concat" {
-  inspect!(
-    @regexp.compile!("cde").matches("abcdef"),
+  inspect(
+    @regexp.compile("cde").matches("abcdef"),
     content=
       #|{success: true, captures: ["cde"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("efg").matches("abcdef"),
+  inspect(
+    @regexp.compile("efg").matches("abcdef"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -138,26 +138,26 @@ test "should match concat" {
 
 ///|
 test "should match alt" {
-  inspect!(
-    @regexp.compile!("a|b|c").matches("a"),
+  inspect(
+    @regexp.compile("a|b|c").matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a|b|c").matches("b"),
+  inspect(
+    @regexp.compile("a|b|c").matches("b"),
     content=
       #|{success: true, captures: ["b"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a|b|c").matches("c"),
+  inspect(
+    @regexp.compile("a|b|c").matches("c"),
     content=
       #|{success: true, captures: ["c"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a|b|c").matches("d"),
+  inspect(
+    @regexp.compile("a|b|c").matches("d"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -166,38 +166,38 @@ test "should match alt" {
 
 ///|
 test "should match class" {
-  inspect!(
-    @regexp.compile!("[abc]").matches("a"),
+  inspect(
+    @regexp.compile("[abc]").matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[abc]").matches("d"),
+  inspect(
+    @regexp.compile("[abc]").matches("d"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[^abc]").matches("a"),
+  inspect(
+    @regexp.compile("[^abc]").matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[^abc]").matches("d"),
+  inspect(
+    @regexp.compile("[^abc]").matches("d"),
     content=
       #|{success: true, captures: ["d"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-zA-Z]").matches("A"),
+  inspect(
+    @regexp.compile("[a-zA-Z]").matches("A"),
     content=
       #|{success: true, captures: ["A"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-zA-Z]").matches("0"),
+  inspect(
+    @regexp.compile("[a-zA-Z]").matches("0"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -206,38 +206,38 @@ test "should match class" {
 
 ///|
 test "should match escape class" {
-  inspect!(
-    @regexp.compile!("[\\d]+").matches("abc123"),
+  inspect(
+    @regexp.compile("[\\d]+").matches("abc123"),
     content=
       #|{success: true, captures: ["123"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[\\D]+").matches("abc123"),
+  inspect(
+    @regexp.compile("[\\D]+").matches("abc123"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[\\s]+").matches("123 abc"),
+  inspect(
+    @regexp.compile("[\\s]+").matches("123 abc"),
     content=
       #|{success: true, captures: [" "], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[\\S]+").matches("123 abc"),
+  inspect(
+    @regexp.compile("[\\S]+").matches("123 abc"),
     content=
       #|{success: true, captures: ["123"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[\\w]+").matches("123abc"),
+  inspect(
+    @regexp.compile("[\\w]+").matches("123abc"),
     content=
       #|{success: true, captures: ["123abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[\\W]+").matches("123abc"),
+  inspect(
+    @regexp.compile("[\\W]+").matches("123abc"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -246,14 +246,14 @@ test "should match escape class" {
 
 ///|
 test "should match class repeat" {
-  inspect!(
-    @regexp.compile!("[a-z]{3}").matches("abc"),
+  inspect(
+    @regexp.compile("[a-z]{3}").matches("abc"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-z]{3}").matches("ab"),
+  inspect(
+    @regexp.compile("[a-z]{3}").matches("ab"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -262,20 +262,20 @@ test "should match class repeat" {
 
 ///|
 test "should match class loop" {
-  inspect!(
-    @regexp.compile!("[a-z]*").matches("abc"),
+  inspect(
+    @regexp.compile("[a-z]*").matches("abc"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-z]*").matches(""),
+  inspect(
+    @regexp.compile("[a-z]*").matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-z]*").matches("123"),
+  inspect(
+    @regexp.compile("[a-z]*").matches("123"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
@@ -284,14 +284,14 @@ test "should match class loop" {
 
 ///|
 test "should match class lazy loop" {
-  inspect!(
-    @regexp.compile!("[a-z]+?").matches("abc"),
+  inspect(
+    @regexp.compile("[a-z]+?").matches("abc"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[a-z]*?").matches("abc"),
+  inspect(
+    @regexp.compile("[a-z]*?").matches("abc"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
@@ -300,26 +300,26 @@ test "should match class lazy loop" {
 
 ///|
 test "should match assert" {
-  inspect!(
-    @regexp.compile!("^abc").matches("abcdef"),
+  inspect(
+    @regexp.compile("^abc").matches("abcdef"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("^def").matches("abcdef"),
+  inspect(
+    @regexp.compile("^def").matches("abcdef"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("abc$").matches("abcdef"),
+  inspect(
+    @regexp.compile("abc$").matches("abcdef"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("def$").matches("abcdef"),
+  inspect(
+    @regexp.compile("def$").matches("abcdef"),
     content=
       #|{success: true, captures: ["def"], named_captures: {}}
     ,
@@ -328,14 +328,14 @@ test "should match assert" {
 
 ///|
 test "should match one or more" {
-  inspect!(
-    @regexp.compile!("a+").matches("aaa"),
+  inspect(
+    @regexp.compile("a+").matches("aaa"),
     content=
       #|{success: true, captures: ["aaa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a+").matches("b"),
+  inspect(
+    @regexp.compile("a+").matches("b"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -344,14 +344,14 @@ test "should match one or more" {
 
 ///|
 test "should match zero or more" {
-  inspect!(
-    @regexp.compile!("a*").matches("aaa"),
+  inspect(
+    @regexp.compile("a*").matches("aaa"),
     content=
       #|{success: true, captures: ["aaa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a*").matches("b"),
+  inspect(
+    @regexp.compile("a*").matches("b"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
@@ -360,14 +360,14 @@ test "should match zero or more" {
 
 ///|
 test "should match zero or one" {
-  inspect!(
-    @regexp.compile!("a?").matches("aaa"),
+  inspect(
+    @regexp.compile("a?").matches("aaa"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a?").matches("b"),
+  inspect(
+    @regexp.compile("a?").matches("b"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
@@ -376,50 +376,50 @@ test "should match zero or one" {
 
 ///|
 test "should match quantifier" {
-  inspect!(
-    @regexp.compile!("a{2}").matches("aa"),
+  inspect(
+    @regexp.compile("a{2}").matches("aa"),
     content=
       #|{success: true, captures: ["aa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{2}").matches("a"),
+  inspect(
+    @regexp.compile("a{2}").matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{1,2}").matches(""),
+  inspect(
+    @regexp.compile("a{1,2}").matches(""),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{1,2}").matches("a"),
+  inspect(
+    @regexp.compile("a{1,2}").matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{1,2}").matches("aa"),
+  inspect(
+    @regexp.compile("a{1,2}").matches("aa"),
     content=
       #|{success: true, captures: ["aa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{2,}").matches("a"),
+  inspect(
+    @regexp.compile("a{2,}").matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{2,}").matches("aa"),
+  inspect(
+    @regexp.compile("a{2,}").matches("aa"),
     content=
       #|{success: true, captures: ["aa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a{2,}").matches("aaaaaaaaaaaaa"),
+  inspect(
+    @regexp.compile("a{2,}").matches("aaaaaaaaaaaaa"),
     content=
       #|{success: true, captures: ["aaaaaaaaaaaaa"], named_captures: {}}
     ,
@@ -428,26 +428,26 @@ test "should match quantifier" {
 
 ///|
 test "should match non-greedy" {
-  inspect!(
-    @regexp.compile!("a*?").matches("aaabc"),
+  inspect(
+    @regexp.compile("a*?").matches("aaabc"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a+?").matches("aaabc"),
+  inspect(
+    @regexp.compile("a+?").matches("aaabc"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("a??").matches("aaabc"),
+  inspect(
+    @regexp.compile("a??").matches("aaabc"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("<.*?>").matches("<foo> <bar> new </bar> </foo>"),
+  inspect(
+    @regexp.compile("<.*?>").matches("<foo> <bar> new </bar> </foo>"),
     content=
       #|{success: true, captures: ["<foo>"], named_captures: {}}
     ,
@@ -456,20 +456,20 @@ test "should match non-greedy" {
 
 ///|
 test "should match group" {
-  inspect!(
-    @regexp.compile!("(abc)|(def)").matches("def"),
+  inspect(
+    @regexp.compile("(abc)|(def)").matches("def"),
     content=
       #|{success: true, captures: ["def", "", "def"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("(a*)bc").matches("aaaaabc"),
+  inspect(
+    @regexp.compile("(a*)bc").matches("aaaaabc"),
     content=
       #|{success: true, captures: ["aaaaabc", "aaaaa"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("(Hello, (?<name>[a-zA-Z]{2,}))! Welcome!").matches(
+  inspect(
+    @regexp.compile("(Hello, (?<name>[a-zA-Z]{2,}))! Welcome!").matches(
       "Hello, John! Welcome!",
     ),
     content=
@@ -480,8 +480,8 @@ test "should match group" {
 
 ///|
 test "should match email address" {
-  inspect!(
-    @regexp.compile!(
+  inspect(
+    @regexp.compile(
       "^(?<addr>[a-zA-Z0-9._%+-]+)@(?<host>[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$",
     ).matches("123456@test.com"),
     content=
@@ -492,28 +492,28 @@ test "should match email address" {
 
 ///|
 test "should handle NotSingle and NotSingleRepeat" {
-  inspect!(
-    @regexp.compile!(".").matches("a"),
+  inspect(
+    @regexp.compile(".").matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[^a]").matches("b"),
+  inspect(
+    @regexp.compile("[^a]").matches("b"),
     content=
       #|{success: true, captures: ["b"], named_captures: {}}
     ,
   )
 
   // Testing NotSingleRepeat
-  inspect!(
-    @regexp.compile!(".{2}").matches("ab"),
+  inspect(
+    @regexp.compile(".{2}").matches("ab"),
     content=
       #|{success: true, captures: ["ab"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!(".{2}").matches("a"),
+  inspect(
+    @regexp.compile(".{2}").matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -522,20 +522,20 @@ test "should handle NotSingle and NotSingleRepeat" {
 
 ///|
 test "should handle NotSingleLoop" {
-  inspect!(
-    @regexp.compile!("[^a]*").matches("bcd"),
+  inspect(
+    @regexp.compile("[^a]*").matches("bcd"),
     content=
       #|{success: true, captures: ["bcd"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[^a]+").matches("bcd"),
+  inspect(
+    @regexp.compile("[^a]+").matches("bcd"),
     content=
       #|{success: true, captures: ["bcd"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("[^a]+").matches("a"),
+  inspect(
+    @regexp.compile("[^a]+").matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
@@ -544,8 +544,8 @@ test "should handle NotSingleLoop" {
 
 ///|
 test "should handle special captures and complex patterns" {
-  inspect!(
-    @regexp.compile!("(a|ab)(bc|c)").matches("abc"),
+  inspect(
+    @regexp.compile("(a|ab)(bc|c)").matches("abc"),
     content=
       #|{success: true, captures: ["abc", "a", "bc"], named_captures: {}}
     ,
@@ -568,8 +568,8 @@ test "should handle special captures and complex patterns" {
   // )
 
   // Test complex loop targets
-  inspect!(
-    @regexp.compile!("(ab)+").matches("ababab"),
+  inspect(
+    @regexp.compile("(ab)+").matches("ababab"),
     content=
       #|{success: true, captures: ["ababab", "ab"], named_captures: {}}
     ,
@@ -578,14 +578,14 @@ test "should handle special captures and complex patterns" {
 
 ///|
 test {
-  inspect!(
-    @regexp.compile!("(a{1,3}?)(a{1,3}?)").matches("aaa"),
+  inspect(
+    @regexp.compile("(a{1,3}?)(a{1,3}?)").matches("aaa"),
     content=
       #|{success: true, captures: ["aa", "a", "a"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("(a{1,3}?)(a{1,3}?)$").matches("aaa"),
+  inspect(
+    @regexp.compile("(a{1,3}?)(a{1,3}?)$").matches("aaa"),
     content=
       #|{success: true, captures: ["aaa", "a", "aa"], named_captures: {}}
     ,
@@ -595,30 +595,30 @@ test {
 ///|
 test "should handle NullMark and other special opcodes" {
   // Using loop repetition which should trigger NullMark
-  inspect!(
-    @regexp.compile!("(abc)*def").matches("abcabcdef"),
+  inspect(
+    @regexp.compile("(abc)*def").matches("abcabcdef"),
     content=
       #|{success: true, captures: ["abcabcdef", "abc"], named_captures: {}}
     ,
   )
-  inspect!(
-    @regexp.compile!("(abc)*def").matches("def"),
+  inspect(
+    @regexp.compile("(abc)*def").matches("def"),
     content=
       #|{success: true, captures: ["def", ""], named_captures: {}}
     ,
   )
 
   // This should test BranchMark in backtracking
-  inspect!(
-    @regexp.compile!("(a*)(b*)").matches("aaabbb"),
+  inspect(
+    @regexp.compile("(a*)(b*)").matches("aaabbb"),
     content=
       #|{success: true, captures: ["aaabbb", "aaa", "bbb"], named_captures: {}}
     ,
   )
 
   // This tests BranchMark with BacktrackingBranch
-  inspect!(
-    @regexp.compile!("(a*)(a*)b").matches("aaab"),
+  inspect(
+    @regexp.compile("(a*)(a*)b").matches("aaab"),
     content=
       #|{success: true, captures: ["aaab", "aaa", ""], named_captures: {}}
     ,
@@ -634,15 +634,15 @@ test "should handle NullMark and other special opcodes" {
 
 ///|
 test "should access regexp pattern" {
-  let re = @regexp.compile!("abc.*")
-  inspect!(re.pattern(), content="abc.*")
+  let re = @regexp.compile("abc.*")
+  inspect(re.pattern(), content="abc.*")
 }
 
 ///|
 test "should access match result captures" {
-  let result = @regexp.compile!("(a)(b)(c)").matches("abc")
+  let result = @regexp.compile("(a)(b)(c)").matches("abc")
   let captures = result.captures()
-  inspect!(
+  inspect(
     captures,
     content=
       #|["abc", "a", "b", "c"]
@@ -653,8 +653,8 @@ test "should access match result captures" {
 ///|
 test "should handle BranchCount and BranchCountLazy opcodes" {
   // This pattern will use BranchCount when compiled
-  let re = @regexp.compile!("(?:abc){2,5}")
-  inspect!(
+  let re = @regexp.compile("(?:abc){2,5}")
+  inspect(
     re.matches("abcabc"),
     content=
       #|{success: true, captures: ["abcabc"], named_captures: {}}
@@ -662,8 +662,8 @@ test "should handle BranchCount and BranchCountLazy opcodes" {
   )
 
   // This pattern will use BranchCountLazy when compiled
-  let re_lazy = @regexp.compile!("(?abc){2,5}?")
-  inspect!(
+  let re_lazy = @regexp.compile("(?abc){2,5}?")
+  inspect(
     re_lazy.matches("abcabcabc"),
     content=
       #|{success: true, captures: ["abcabc", "abc"], named_captures: {}}
@@ -674,8 +674,8 @@ test "should handle BranchCount and BranchCountLazy opcodes" {
 ///|
 test "should handle NotSingleLoop opcode" {
   // This pattern uses NotSingleLoop to match any character except 'a' repeated
-  let re = @regexp.compile!("[^a]+")
-  inspect!(
+  let re = @regexp.compile("[^a]+")
+  inspect(
     re.matches("bcde"),
     content=
       #|{success: true, captures: ["bcde"], named_captures: {}}
@@ -683,7 +683,7 @@ test "should handle NotSingleLoop opcode" {
   )
 
   // Test that it fails when only 'a' is present
-  inspect!(
+  inspect(
     re.matches("a"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
@@ -691,7 +691,7 @@ test "should handle NotSingleLoop opcode" {
   )
 
   // Test with mixed content
-  inspect!(
+  inspect(
     re.matches("bcadef"),
     content=
       #|{success: true, captures: ["bc"], named_captures: {}}
@@ -702,8 +702,8 @@ test "should handle NotSingleLoop opcode" {
 ///|
 test "should handle ClassLazy opcode" {
   // This pattern uses ClassLazy to match classes lazily
-  let re = @regexp.compile!("[a-z]{1,5}?")
-  inspect!(
+  let re = @regexp.compile("[a-z]{1,5}?")
+  inspect(
     re.matches("abcde"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
@@ -711,8 +711,8 @@ test "should handle ClassLazy opcode" {
   )
 
   // Test that it keeps matching when forced to by the pattern
-  let re2 = @regexp.compile!("[a-z]{1,5}?c")
-  inspect!(
+  let re2 = @regexp.compile("[a-z]{1,5}?c")
+  inspect(
     re2.matches("abc"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
@@ -723,8 +723,8 @@ test "should handle ClassLazy opcode" {
 ///|
 test "should handle NullMark in simple capture" {
   // This should use NullMark internally
-  let re = @regexp.compile!("(a*)")
-  inspect!(
+  let re = @regexp.compile("(a*)")
+  inspect(
     re.matches(""),
     content=
       #|{success: true, captures: ["", ""], named_captures: {}}
@@ -735,8 +735,8 @@ test "should handle NullMark in simple capture" {
 ///|
 test "should handle BranchMark in captures" {
   // This should use BranchMark
-  let re = @regexp.compile!("(a*)(b)")
-  inspect!(
+  let re = @regexp.compile("(a*)(b)")
+  inspect(
     re.matches("aaab"),
     content=
       #|{success: true, captures: ["aaab", "aaa", "b"], named_captures: {}}
@@ -747,8 +747,8 @@ test "should handle BranchMark in captures" {
 ///|
 test "should handle NotSingleRepeat opcode" {
   // This tests NotSingleRepeat
-  let re = @regexp.compile!("[^a]{2}")
-  inspect!(
+  let re = @regexp.compile("[^a]{2}")
+  inspect(
     re.matches("bc"),
     content=
       #|{success: true, captures: ["bc"], named_captures: {}}
@@ -756,7 +756,7 @@ test "should handle NotSingleRepeat opcode" {
   )
 
   // Test failure case
-  inspect!(
+  inspect(
     re.matches("ac"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
@@ -767,8 +767,8 @@ test "should handle NotSingleRepeat opcode" {
 ///|
 test "should handle SetCount and related count operations" {
   // This should use SetCount for quantifiers with min > 1
-  let re = @regexp.compile!("a{3,5}")
-  inspect!(
+  let re = @regexp.compile("a{3,5}")
+  inspect(
     re.matches("aaa"),
     content=
       #|{success: true, captures: ["aaa"], named_captures: {}}
@@ -776,8 +776,8 @@ test "should handle SetCount and related count operations" {
   )
 
   // Test with exact count
-  let re2 = @regexp.compile!("a{3}")
-  inspect!(
+  let re2 = @regexp.compile("a{3}")
+  inspect(
     re2.matches("aaa"),
     content=
       #|{success: true, captures: ["aaa"], named_captures: {}}
@@ -785,8 +785,8 @@ test "should handle SetCount and related count operations" {
   )
 
   // Test with min=0
-  let re3 = @regexp.compile!("a{0,3}")
-  inspect!(
+  let re3 = @regexp.compile("a{0,3}")
+  inspect(
     re3.matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
@@ -797,8 +797,8 @@ test "should handle SetCount and related count operations" {
 ///|
 test "should handle BranchMarkLazy opcode" {
   // This uses lazy matching with BranchMarkLazy
-  let re = @regexp.compile!("(a*?)b")
-  inspect!(
+  let re = @regexp.compile("(a*?)b")
+  inspect(
     re.matches("aaab"),
     content=
       #|{success: true, captures: ["aaab", "aaa"], named_captures: {}}
@@ -809,8 +809,8 @@ test "should handle BranchMarkLazy opcode" {
 ///|
 test "should handle NullCount opcode" {
   // This should use NullCount
-  let re = @regexp.compile!("(a{0,5})")
-  inspect!(
+  let re = @regexp.compile("(a{0,5})")
+  inspect(
     re.matches(""),
     content=
       #|{success: true, captures: ["", ""], named_captures: {}}
@@ -821,8 +821,8 @@ test "should handle NullCount opcode" {
 ///|
 test "should handle fixed quantifiers in classes" {
   // This should use ClassRepeat for matching char classes with specific lengths
-  let re = @regexp.compile!("[0-9]{3}")
-  inspect!(
+  let re = @regexp.compile("[0-9]{3}")
+  inspect(
     re.matches("123"),
     content=
       #|{success: true, captures: ["123"], named_captures: {}}
@@ -830,8 +830,8 @@ test "should handle fixed quantifiers in classes" {
   )
 
   // Test with min/max range
-  let re2 = @regexp.compile!("[0-9]{2,4}")
-  inspect!(
+  let re2 = @regexp.compile("[0-9]{2,4}")
+  inspect(
     re2.matches("123"),
     content=
       #|{success: true, captures: ["123"], named_captures: {}}
@@ -839,8 +839,8 @@ test "should handle fixed quantifiers in classes" {
   )
 
   // Test with unbounded max
-  let re3 = @regexp.compile!("[0-9]{2,}")
-  inspect!(
+  let re3 = @regexp.compile("[0-9]{2,}")
+  inspect(
     re3.matches("12345"),
     content=
       #|{success: true, captures: ["12345"], named_captures: {}}
@@ -851,8 +851,8 @@ test "should handle fixed quantifiers in classes" {
 ///|
 test "should handle dash in character classes" {
   // This should test dash in character classes
-  let re = @regexp.compile!("[-a]")
-  inspect!(
+  let re = @regexp.compile("[-a]")
+  inspect(
     re.matches("-"),
     content=
       #|{success: true, captures: ["-"], named_captures: {}}
@@ -863,8 +863,8 @@ test "should handle dash in character classes" {
 ///|
 test "should handle complex repetition cases" {
   // Test with lazy matching of NotSingleLoop
-  let re = @regexp.compile!("[^a]*?")
-  inspect!(
+  let re = @regexp.compile("[^a]*?")
+  inspect(
     re.matches("bcd"),
     content=
       #|{success: true, captures: [""], named_captures: {}}
@@ -872,8 +872,8 @@ test "should handle complex repetition cases" {
   )
 
   // Test with ClassLazy and multiple matches
-  let re2 = @regexp.compile!("[0-9]+?[a-z]")
-  inspect!(
+  let re2 = @regexp.compile("[0-9]+?[a-z]")
+  inspect(
     re2.matches("123a456b"),
     content=
       #|{success: true, captures: ["123a"], named_captures: {}}
@@ -881,8 +881,8 @@ test "should handle complex repetition cases" {
   )
 
   // Test with SingleLazy and backtracking
-  let re3 = @regexp.compile!("a+?b")
-  inspect!(
+  let re3 = @regexp.compile("a+?b")
+  inspect(
     re3.matches("aab"),
     content=
       #|{success: true, captures: ["aab"], named_captures: {}}
@@ -893,8 +893,8 @@ test "should handle complex repetition cases" {
 ///|
 test "should handle non-capturing groups with explicit flags" {
   // Test non-capturing group with a colon
-  let re = @regexp.compile!("(?:abc)")
-  inspect!(
+  let re = @regexp.compile("(?:abc)")
+  inspect(
     re.matches("abc"),
     content=
       #|{success: true, captures: ["abc"], named_captures: {}}
@@ -902,14 +902,14 @@ test "should handle non-capturing groups with explicit flags" {
   )
 
   // Test non-capturing group with alternation
-  let re2 = @regexp.compile!("(?:a|b)c")
-  inspect!(
+  let re2 = @regexp.compile("(?:a|b)c")
+  inspect(
     re2.matches("ac"),
     content=
       #|{success: true, captures: ["ac"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re2.matches("bc"),
     content=
       #|{success: true, captures: ["bc"], named_captures: {}}
@@ -920,20 +920,20 @@ test "should handle non-capturing groups with explicit flags" {
 ///|
 test "should handle complex character classes" {
   // Test character class with ranges and individual characters
-  let re = @regexp.compile!("[a-z0-9_]")
-  inspect!(
+  let re = @regexp.compile("[a-z0-9_]")
+  inspect(
     re.matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re.matches("5"),
     content=
       #|{success: true, captures: ["5"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re.matches("_"),
     content=
       #|{success: true, captures: ["_"], named_captures: {}}
@@ -941,14 +941,14 @@ test "should handle complex character classes" {
   )
 
   // Test inverted class
-  let re2 = @regexp.compile!("[^0-9]")
-  inspect!(
+  let re2 = @regexp.compile("[^0-9]")
+  inspect(
     re2.matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re2.matches("5"),
     content=
       #|{success: false, captures: [""], named_captures: {}}
@@ -958,9 +958,9 @@ test "should handle complex character classes" {
 
 ///|
 test "should handle named captures" {
-  let re = @regexp.compile!("(?<name>a)")
+  let re = @regexp.compile("(?<name>a)")
   let result = re.matches("a")
-  inspect!(
+  inspect(
     result,
     content=
       #|{success: true, captures: ["a", "a"], named_captures: {"name": "a"}}
@@ -970,92 +970,92 @@ test "should handle named captures" {
 
 ///|
 test "panic UnmatchedGroupEnd" {
-  let _ = @regexp.compile!("a)")
+  let _ = @regexp.compile("a)")
 
 }
 
 ///|
 test "panic UnmatchedCharClassEnd" {
-  let _ = @regexp.compile!("a]")
+  let _ = @regexp.compile("a]")
 
 }
 
 ///|
 test "panic UnspecifiedLoopTarget" {
-  let _ = @regexp.compile!("*")
+  let _ = @regexp.compile("*")
 
 }
 
 ///|
 test "panic InvalidLoop" {
-  let _ = @regexp.compile!("a{}")
+  let _ = @regexp.compile("a{}")
 
 }
 
 ///|
 test "panic LoopCountOutOfRange" {
-  let _ = @regexp.compile!("a{999999999}")
+  let _ = @regexp.compile("a{999999999}")
 
 }
 
 ///|
 test "panic LoopMaxCountSmallerThanMinCount" {
-  let _ = @regexp.compile!("a{5,3}")
+  let _ = @regexp.compile("a{5,3}")
 
 }
 
 ///|
 test "panic UnmatchedGroupBegin" {
-  let _ = @regexp.compile!("(")
+  let _ = @regexp.compile("(")
 
 }
 
 ///|
 test "panic EmptyGroupName" {
-  let _ = @regexp.compile!("(?<>a)")
+  let _ = @regexp.compile("(?<>a)")
 
 }
 
 ///|
 test "panic EmptyGroup" {
-  let _ = @regexp.compile!("()")
+  let _ = @regexp.compile("()")
 
 }
 
 ///|
 test "panic GroupMissingParen" {
-  let _ = @regexp.compile!("(abc")
+  let _ = @regexp.compile("(abc")
 
 }
 
 ///|
 test "panic UnmatchedGroupName" {
-  let _ = @regexp.compile!("(?<name")
+  let _ = @regexp.compile("(?<name")
 
 }
 
 ///|
 test "panic ClassMissingBracket" {
-  let _ = @regexp.compile!("[abc")
+  let _ = @regexp.compile("[abc")
 
 }
 
 ///|
 test "panic EndPatternAtEscape" {
-  let _ = @regexp.compile!("\\")
+  let _ = @regexp.compile("\\")
 
 }
 
 ///|
 test "should handle empty pattern alternation" {
-  let re = @regexp.compile!("a|")
-  inspect!(
+  let re = @regexp.compile("a|")
+  inspect(
     re.matches("a"),
     content=
       #|{success: true, captures: ["a"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re.matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
@@ -1065,8 +1065,8 @@ test "should handle empty pattern alternation" {
 
 ///|
 test "should handle empty pattern" {
-  let re = @regexp.compile!("")
-  inspect!(
+  let re = @regexp.compile("")
+  inspect(
     re.matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
@@ -1076,20 +1076,20 @@ test "should handle empty pattern" {
 
 ///|
 test "should handle escaped special characters in character classes" {
-  let re = @regexp.compile!("[\\t\\r\\n]")
-  inspect!(
+  let re = @regexp.compile("[\\t\\r\\n]")
+  inspect(
     re.matches("\t"),
     content=
       #|{success: true, captures: ["\t"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re.matches("\r"),
     content=
       #|{success: true, captures: ["\r"], named_captures: {}}
     ,
   )
-  inspect!(
+  inspect(
     re.matches("\n"),
     content=
       #|{success: true, captures: ["\n"], named_captures: {}}
@@ -1100,8 +1100,8 @@ test "should handle escaped special characters in character classes" {
 ///|
 test "should handle custom escape characters in character classes" {
   // Test with a custom escape character in a character class
-  let re = @regexp.compile!("[\\x]")
-  inspect!(
+  let re = @regexp.compile("[\\x]")
+  inspect(
     re.matches("x"),
     content=
       #|{success: true, captures: ["x"], named_captures: {}}
@@ -1111,8 +1111,8 @@ test "should handle custom escape characters in character classes" {
 
 ///|
 test "should handle backslashed characters in character classes" {
-  let re = @regexp.compile!("[\\\\]")
-  inspect!(
+  let re = @regexp.compile("[\\\\]")
+  inspect(
     re.matches("\\"),
     content=
       #|{success: true, captures: ["\\"], named_captures: {}}
@@ -1123,24 +1123,24 @@ test "should handle backslashed characters in character classes" {
 ///|
 test "should handle escape sequences within character classes" {
   // Test backslash within character class
-  inspect!(
-    @regexp.compile!("[\\\\abc]").matches("\\"),
+  inspect(
+    @regexp.compile("[\\\\abc]").matches("\\"),
     content=
       #|{success: true, captures: ["\\"], named_captures: {}}
     ,
   )
 
   // Test hyphen at the end of character class
-  inspect!(
-    @regexp.compile!("[abc-]").matches("-"),
+  inspect(
+    @regexp.compile("[abc-]").matches("-"),
     content=
       #|{success: true, captures: ["-"], named_captures: {}}
     ,
   )
 
   // Test caret not at the beginning
-  inspect!(
-    @regexp.compile!("[a^b]").matches("^"),
+  inspect(
+    @regexp.compile("[a^b]").matches("^"),
     content=
       #|{success: true, captures: ["^"], named_captures: {}}
     ,
@@ -1150,16 +1150,16 @@ test "should handle escape sequences within character classes" {
 ///|
 test "should handle nested groups with quantifiers" {
   // Test nested capturing groups
-  inspect!(
-    @regexp.compile!("((a)b(c))").matches("abc"),
+  inspect(
+    @regexp.compile("((a)b(c))").matches("abc"),
     content=
       #|{success: true, captures: ["abc", "abc", "a", "c"], named_captures: {}}
     ,
   )
 
   // Test nested groups with quantifiers
-  inspect!(
-    @regexp.compile!("((a+)b)+").matches("abaab"),
+  inspect(
+    @regexp.compile("((a+)b)+").matches("abaab"),
     content=
       #|{success: true, captures: ["abaab", "aab", "aa"], named_captures: {}}
     ,
@@ -1169,24 +1169,24 @@ test "should handle nested groups with quantifiers" {
 ///|
 test "should handle complex alternations" {
   // Test alternation with empty options
-  inspect!(
-    @regexp.compile!("a||b").matches(""),
+  inspect(
+    @regexp.compile("a||b").matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
   )
 
   // Test alternation with groups
-  inspect!(
-    @regexp.compile!("(a|b)(c|d)").matches("ac"),
+  inspect(
+    @regexp.compile("(a|b)(c|d)").matches("ac"),
     content=
       #|{success: true, captures: ["ac", "a", "c"], named_captures: {}}
     ,
   )
 
   // Test alternation with different lengths
-  inspect!(
-    @regexp.compile!("abc|ab|a").matches("ab"),
+  inspect(
+    @regexp.compile("abc|ab|a").matches("ab"),
     content=
       #|{success: true, captures: ["ab"], named_captures: {}}
     ,
@@ -1196,24 +1196,24 @@ test "should handle complex alternations" {
 ///|
 test "should handle boundary cases for quantifiers" {
   // Test zero-width quantifier
-  inspect!(
-    @regexp.compile!("a{0}").matches(""),
+  inspect(
+    @regexp.compile("a{0}").matches(""),
     content=
       #|{success: true, captures: [""], named_captures: {}}
     ,
   )
 
   // Test minimum boundary
-  inspect!(
-    @regexp.compile!("a{1,}").matches(""),
+  inspect(
+    @regexp.compile("a{1,}").matches(""),
     content=
       #|{success: false, captures: [""], named_captures: {}}
     ,
   )
 
   // Test exact boundary
-  inspect!(
-    @regexp.compile!("a{3,3}").matches("aaa"),
+  inspect(
+    @regexp.compile("a{3,3}").matches("aaa"),
     content=
       #|{success: true, captures: ["aaa"], named_captures: {}}
     ,
@@ -1223,16 +1223,16 @@ test "should handle boundary cases for quantifiers" {
 ///|
 test "should handle named captures with complex patterns" {
   // Test multiple named captures
-  inspect!(
-    @regexp.compile!("(?<first>a+)(?<second>b+)").matches("aabb"),
+  inspect(
+    @regexp.compile("(?<first>a+)(?<second>b+)").matches("aabb"),
     content=
       #|{success: true, captures: ["aabb", "aa", "bb"], named_captures: {"first": "aa", "second": "bb"}}
     ,
   )
 
   // Test nested named captures
-  inspect!(
-    @regexp.compile!("(?<outer>a(?<inner>b+)c)").matches("abbc"),
+  inspect(
+    @regexp.compile("(?<outer>a(?<inner>b+)c)").matches("abbc"),
     content=
       #|{success: true, captures: ["abbc", "abbc", "bb"], named_captures: {"outer": "abbc", "inner": "bb"}}
     ,
@@ -1242,16 +1242,16 @@ test "should handle named captures with complex patterns" {
 ///|
 test "should handle complex nested groups with lookahead and quantifiers" {
   // Complex nested groups
-  inspect!(
-    @regexp.compile!("((a{2,3})b+)*(c?)").matches("aabaabc"),
+  inspect(
+    @regexp.compile("((a{2,3})b+)*(c?)").matches("aabaabc"),
     content=
       #|{success: true, captures: ["aabaabc", "aab", "aa", "c"], named_captures: {}}
     ,
   )
 
   // Multiple groups with alternations
-  inspect!(
-    @regexp.compile!("(a|b)*c((d|e){2,3})(f|g)?").matches("abcddef"),
+  inspect(
+    @regexp.compile("(a|b)*c((d|e){2,3})(f|g)?").matches("abcddef"),
     content=
       #|{success: true, captures: ["abcddef", "b", "dde", "e", "f"], named_captures: {}}
     ,
@@ -1261,8 +1261,8 @@ test "should handle complex nested groups with lookahead and quantifiers" {
 ///|
 test "should handle complex named captures with nested groups" {
   // Nested named captures with quantifiers
-  inspect!(
-    @regexp.compile!("(?<outer>a(?<middle>b(?<inner>c{1,2})d)*e)f").matches(
+  inspect(
+    @regexp.compile("(?<outer>a(?<middle>b(?<inner>c{1,2})d)*e)f").matches(
       "abcdbcdef",
     ),
     content=
@@ -1271,8 +1271,8 @@ test "should handle complex named captures with nested groups" {
   )
 
   // Multiple named captures with alternations
-  inspect!(
-    @regexp.compile!("(?<first>[0-9]+)(?<sep>[,-]?)(?<second>[a-z]+)").matches(
+  inspect(
+    @regexp.compile("(?<first>[0-9]+)(?<sep>[,-]?)(?<second>[a-z]+)").matches(
       "123-abc",
     ),
     content=
@@ -1284,16 +1284,16 @@ test "should handle complex named captures with nested groups" {
 ///|
 test "should handle complex lazy and greedy quantifier interactions" {
   // Lazy and greedy quantifier combinations
-  inspect!(
-    @regexp.compile!("(a+?b+)(a+b+?)").matches("aabaaab"),
+  inspect(
+    @regexp.compile("(a+?b+)(a+b+?)").matches("aabaaab"),
     content=
       #|{success: true, captures: ["aabaaab", "aab", "aaab"], named_captures: {}}
     ,
   )
 
   // Nested lazy quantifiers
-  inspect!(
-    @regexp.compile!("(a*?b+?)*(c*?)").matches("ababc"),
+  inspect(
+    @regexp.compile("(a*?b+?)*(c*?)").matches("ababc"),
     content=
       #|{success: true, captures: ["abab", "ab", ""], named_captures: {}}
     ,
@@ -1303,16 +1303,16 @@ test "should handle complex lazy and greedy quantifier interactions" {
 ///|
 test "should handle complex boundary conditions" {
   // Mixed boundary conditions
-  inspect!(
-    @regexp.compile!("^([a-z]+?)([0-9]+)$").matches("abc123"),
+  inspect(
+    @regexp.compile("^([a-z]+?)([0-9]+)$").matches("abc123"),
     content=
       #|{success: true, captures: ["abc123", "abc", "123"], named_captures: {}}
     ,
   )
 
   // Empty matches within groups
-  inspect!(
-    @regexp.compile!("(a*)(b*)(c*)").matches(""),
+  inspect(
+    @regexp.compile("(a*)(b*)(c*)").matches(""),
     content=
       #|{success: true, captures: ["", "", "", ""], named_captures: {}}
     ,

--- a/src/result.mbt
+++ b/src/result.mbt
@@ -27,14 +27,14 @@ test "get captures" {
     captures: ["123456789", "123", "456", "789"],
     named_captures: { "a": "123", "b": "456", "c": "789" },
   }
-  inspect!(res.success(), content="true")
-  inspect!(
+  inspect(res.success(), content="true")
+  inspect(
     res.captures,
     content=
       #|["123456789", "123", "456", "789"]
     ,
   )
-  inspect!(
+  inspect(
     res.named_captures(),
     content=
       #|{"a": "123", "b": "456", "c": "789"}


### PR DESCRIPTION
Update to v0.1.20250612

Apart from syntax changes (use `raise` instead of `!`, `suberror` instead of `type!`, rename `class` to `clazz`, etc), there are two notable changes:

1. there's no longer complex default parameters that depend on the first ones, so `matches` is transformed to use optional argument with `Option.or`.
2. to make `"string"[index]` more clear, `String::op_get` is deprecated, and replaced by `String::charcode_at` and `Int::unsafe_to_char`.